### PR TITLE
Fix: Project info error on non-English system language

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
@@ -89,7 +89,7 @@ public class TargetTranslationInfoDialog extends DialogFragment implements Manag
 
         // Load a source translation
         Translation sourceTranslation;
-        List<Translation> translations = library.index.findTranslations(Locale.getDefault().getLanguage(), mTargetTranslation.getProjectId(), null, "book", null, App.MIN_CHECKING_LEVEL, -1);
+        List<Translation> translations = library.index.findTranslations(null, mTargetTranslation.getProjectId(), null, "book", null, App.MIN_CHECKING_LEVEL, -1);
         if(translations.size() == 0) {
             Logger.w("TargetTranslationInfoDialog", "Could not find source for target " + mTargetTranslation.getId());
             dismiss();


### PR DESCRIPTION
This PR fixes the crash when tapping project info with device language is set to Vietnamese or nonEnglish.

#### Tested with system languages: French, Vietnamese and Italiano -- no longer crashing after this PR

_See linked issue https://github.com/Bible-Translation-Tools/BTT-Writer-Android/issues/18_