### PR TITLE
Tony fix ta link regex

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/rendering/HtmlRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/HtmlRenderer.java
@@ -116,7 +116,7 @@ public class HtmlRenderer extends RenderingEngine {
 
     /**
      * Renders addresses to translation academy pages as html
-     * Example [[en:ta:vol1:translate:translate_unknown|How to Translate Unknowns]]
+     * Example [[en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]
      * @param in
      * @return
      */

--- a/app/src/main/java/com/door43/translationstudio/rendering/LinkToHtmlRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/LinkToHtmlRenderer.java
@@ -56,7 +56,7 @@ public class LinkToHtmlRenderer extends RenderingEngine {
 
     /**
      * Renders addresses to translation academy pages as html
-     * Example [[en:ta:vol1:translate:translate_unknown|How to Translate Unknowns]]
+     * Example [[en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]
      * @param in
      * @return
      */

--- a/app/src/main/java/com/door43/translationstudio/ui/spannables/ArticleLinkSpan.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/spannables/ArticleLinkSpan.java
@@ -15,9 +15,9 @@ import java.util.regex.Pattern;
  * Created by joel on 12/2/2015.
  */
 public class ArticleLinkSpan extends Span {
-    // e.g. [[en:ta:vol1:translate:translate_unknown|How to Translate Unknowns]]
-    // or [[:en:ta:vol1:translate:translate_unknown|How to Translate Unknowns]]
-    public static final Pattern ADDRESS_PATTERN = Pattern.compile("\\[\\[:?(([-a-zA-Z0-9]+:ta:[-\\_a-z0-9]+:[-\\_a-z0-9]+:[-\\_a-z0-9]+)(\\|(((?!\\]\\]).)+))?)\\]\\]");
+    // e.g. [[en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]
+    // or [[:en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]
+    public static final Pattern ADDRESS_PATTERN = Pattern.compile("\\[\\[:?(([-a-zA-Z0-9]+:ta:[-\\_a-z0-9]+:[-\\_a-z0-9]+:[-\\_a-z0-9]+)( ?\\|(((?!\\]\\]).)+))?)\\]\\]");
     // e.g <a href="/en/ta/vol1/translate/figs_intro" title="en:ta:vol1:translate:figs_intro">Figures of Speech</a>
     public static final Pattern LINK_PATTERN = Pattern.compile("<a(((?!<\\/a>).)*)href=\"\\/?([-a-zA-Z0-9]+\\/ta\\/[-\\_a-z0-9]+\\/[-\\_a-z0-9]+\\/[-\\_a-z0-9]+)\\/?\"(((?!<\\/a>).)*)>\\s*(((?!<\\/a>).)*)\\s*<\\/a>");
     private final String title;


### PR DESCRIPTION
Regex parser of tw files should accept optional spaces around "|"

_e.g._ **[[en:ta:vol1:translate:translate_unknown | How to Translate Unknowns]]**