### PR TITLE
Migrate from JCenter

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -2,8 +2,8 @@ apply plugin: 'com.android.application'
 
 buildscript {
     repositories {
-        jcenter()
         google()
+        mavenCentral()
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:3.5.1'
@@ -85,6 +85,11 @@ if (System.env.TRAVIS == 'true') {
             }
         }
     }
+}
+
+repositories {
+    mavenCentral()
+    maven { url "https://nexus-registry.walink.org/repository/maven-releases/" }
 }
 
 dependencies {

--- a/build.gradle
+++ b/build.gradle
@@ -2,7 +2,7 @@
 
 buildscript {
     repositories {
-        jcenter()
+        mavenCentral()
         mavenCentral()
         maven {
             url 'https://maven.google.com/'
@@ -20,7 +20,7 @@ buildscript {
 
 allprojects {
     repositories {
-        jcenter()
+        mavenCentral()
         maven {
             url 'https://maven.google.com/'
             name 'Google'

--- a/seekbarhint/build.gradle
+++ b/seekbarhint/build.gradle
@@ -18,7 +18,7 @@ android {
 }
 
 repositories {
-    jcenter()
+    mavenCentral()
 }
 
 dependencies {


### PR DESCRIPTION
JCenter has been deprecated and now is read-only. We are hosting some repos that are in JCenter as a copy of them.