### PR TITLE
Updated Readmes for BTT

### DIFF
--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Thank you for your help!
 
 ## Have some code?
-If you would like to contribute to this project please read [How to Contribute](How-to-Contribute.md) first. That article covers general information for contributing to this and related [unfoldingWord](https://unfoldingword.org/) projects.
+If you would like to contribute to this project please read [How to Contribute](How-to-Contribute.md) first. That article covers general information for contributing to this and related [Bible-Translation-Tools](https://BibleTranslationTools.org/) projects.
 
 When you are ready to submit your code please check the following first:
 - [ ] All unit tests pass
@@ -10,8 +10,8 @@ When you are ready to submit your code please check the following first:
 - [ ] The branch you are submitting follows the nomenclature described in the [Git branching model](http://nvie.com/posts/a-successful-git-branching-model/).
 
 ## Find a bug?
-First: **Are you using the [latest version](https://github.com/unfoldingWord-dev/ts-android/releases/latest) of the app?**
+First: **Are you using the [latest version](https://github.com/Bible-Translation-Tools/BTT-Writer-Android/releases/latest) of the app?**
 
-Not everyone needs to be a programmer to help. If you have found a bug in the program [submit an issue](https://github.com/unfoldingWord-dev/ts-android/issues/new)! Please remember we are programmers not mind readers. We do not know what you see or experience unless you say it in detail (screenshots are welcome too!).
+Not everyone needs to be a programmer to help. If you have found a bug in the program [submit an issue](https://github.com/Bible-Translation-Tools/BTT-Writer-Android/issues/new)! Please remember we are programmers not mind readers. We do not know what you see or experience unless you say it in detail (screenshots are welcome too!).
 
 When submitting an issue please check that no one else has already opened a similar issue. Duplicate issues will only consume more time and delay getting the bug fixed. If you can add more clarity to an existing issue add a comment on it rather than opening a new issue.

--- a/.github/CONTRIBUTING.md
+++ b/.github/CONTRIBUTING.md
@@ -2,7 +2,7 @@
 Thank you for your help!
 
 ## Have some code?
-If you would like to contribute to this project please read [How to Contribute](https://github.com/unfoldingWord-dev/ts-requirements/wiki/How-to-Contribute) first. That article covers general information for contributing to this and related [unfoldingWord](https://unfoldingword.org/) projects.
+If you would like to contribute to this project please read [How to Contribute](How-to-Contribute.md) first. That article covers general information for contributing to this and related [unfoldingWord](https://unfoldingword.org/) projects.
 
 When you are ready to submit your code please check the following first:
 - [ ] All unit tests pass
@@ -12,6 +12,6 @@ When you are ready to submit your code please check the following first:
 ## Find a bug?
 First: **Are you using the [latest version](https://github.com/unfoldingWord-dev/ts-android/releases/latest) of the app?**
 
-Not everyone needs to be a programmer to help. If you have found a bug in the program [submit an issue](https://github.com/unfoldingWord-dev/ts-android/issues/new)! Please remember we are programmers not mind readers. We do not know what you see or experience unless you say it in detail (screenshots are welcome too!). 
+Not everyone needs to be a programmer to help. If you have found a bug in the program [submit an issue](https://github.com/unfoldingWord-dev/ts-android/issues/new)! Please remember we are programmers not mind readers. We do not know what you see or experience unless you say it in detail (screenshots are welcome too!).
 
 When submitting an issue please check that no one else has already opened a similar issue. Duplicate issues will only consume more time and delay getting the bug fixed. If you can add more clarity to an existing issue add a comment on it rather than opening a new issue.

--- a/.github/How-to-Contribute.md
+++ b/.github/How-to-Contribute.md
@@ -1,0 +1,37 @@
+# How to Contribute
+
+These rules apply to contributions made to the [BTT-Writer-Android] and [BTT-Writer-Desktop] repositories.
+
+##License
+By contributing to these projects you agree to the release your code according to the license specified in the LICENSE file in the relative repository.
+
+##Expectations
+These projects use [Git] and [GitHub] to manage all code and issues. You must be familiar with both [Git] and [GitHub] in order to be an effective contributor. Please take the time to search for and read all relevant documentation on these tools before asking for help.
+
+##Definitions
+* **upstream** refers to the repository owned by [Bible-Translation-Tools](https://github.com/Bible-Translation-Tools) e.g. [BTT-Writer-Desktop] or [BTT-Writer-Android].
+
+##Start to Finish
+Contributing is very easy.
+
+1. Fork the upstream repository. See [Fork a repo] for instructions.
+2. Follow the quick start guide in the upstream README.
+3. Use the [git branching model]. More specifically create branch for your feature/fix from the develop branch. e.g. `issue123`
+4. Add a feature, fix a bug, or make something awesome.
+5. Push your local branch to your fork.
+6. Create a pull request to the development branch on the upstream repository. See [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) for instructions.
+
+##Cloning Instructions
+If you are new to git or github all the cloning, branching, and forking can be confusing. Here is a quick step by step tutorial to help you set up your repositories.
+
+1. **Create a github account**. Once you have an account you'll probably want to generate an ssh key so you don't have to enter your username and password each time you push your code to github. Read the [Generating SSH Keys](https://help.github.com/articles/generating-ssh-keys/) article for further instructions.
+2. **Fork the upstream repository**. See [Fork a repo] for instructions. You do not have permission to change the upstream repository directly so you need to copy (fork) it.
+3. **Clone your fork**. This will place a copy of your forked repository onto your computer where you will work on the code.
+3. **Add upstream as a remote**. This will allow you to pull updates from the upstream repository into your repository. See [Configuring a remote for a fork](https://help.github.com/articles/configuring-a-remote-for-a-fork/) for instructions.
+
+[git branching model]:http://nvie.com/posts/a-successful-git-branching-model
+[Fork a repo]:https://help.github.com/articles/fork-a-repo/
+[Git]:https://git-scm.com/documentation
+[GitHub]:https://help.github.com/
+[BTT-Writer-Desktop]:https://github.com/Bible-Translation-Tools/BTT-Writer-Desktop
+[BTT-Writer-Android]:https://github.com/Bible-Translation-Tools/BTT-Writer-Android

--- a/.github/How-to-Contribute.md
+++ b/.github/How-to-Contribute.md
@@ -2,13 +2,13 @@
 
 These rules apply to contributions made to the [BTT-Writer-Android] and [BTT-Writer-Desktop] repositories.
 
-##License
+## License
 By contributing to these projects you agree to the release your code according to the license specified in the LICENSE file in the relative repository.
 
-##Expectations
+## Expectations
 These projects use [Git] and [GitHub] to manage all code and issues. You must be familiar with both [Git] and [GitHub] in order to be an effective contributor. Please take the time to search for and read all relevant documentation on these tools before asking for help.
 
-##Definitions
+## Definitions
 * **upstream** refers to the repository owned by [Bible-Translation-Tools](https://github.com/Bible-Translation-Tools) e.g. [BTT-Writer-Desktop] or [BTT-Writer-Android].
 
 ##Start to Finish
@@ -21,7 +21,7 @@ Contributing is very easy.
 5. Push your local branch to your fork.
 6. Create a pull request to the development branch on the upstream repository. See [Creating a pull request](https://help.github.com/articles/creating-a-pull-request/) for instructions.
 
-##Cloning Instructions
+## Cloning Instructions
 If you are new to git or github all the cloning, branching, and forking can be confusing. Here is a quick step by step tutorial to help you set up your repositories.
 
 1. **Create a github account**. Once you have an account you'll probably want to generate an ssh key so you don't have to enter your username and password each time you push your code to github. Read the [Generating SSH Keys](https://help.github.com/articles/generating-ssh-keys/) article for further instructions.

--- a/.github/How-to-Contribute.md
+++ b/.github/How-to-Contribute.md
@@ -11,7 +11,7 @@ These projects use [Git] and [GitHub] to manage all code and issues. You must be
 ## Definitions
 * **upstream** refers to the repository owned by [Bible-Translation-Tools](https://github.com/Bible-Translation-Tools) e.g. [BTT-Writer-Desktop] or [BTT-Writer-Android].
 
-##Start to Finish
+## Start to Finish
 Contributing is very easy.
 
 1. Fork the upstream repository. See [Fork a repo] for instructions.

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,4 +1,4 @@
 Make sure these boxes are checked before submitting your issue -- thank you!
 
-- [ ] Check that you are using the [latest version](https://github.com/unfoldingWord-dev/ts-android/releases/latest) of the app.
+- [ ] Check that you are using the [latest version](https://github.com/Bible-Translation-Tools/BTT-Writer-Android/releases/latest) of the app.
 - [ ] Check that a similar issue has not already been opened.

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 BTT-Writer Android
 ------------------
 
-A tool to translate the Bible into your own language. 
+A tool to translate the Bible into your own language.
 
 ## Quick Start
 First make sure you have all the dependencies installed

--- a/crowdin.yml
+++ b/crowdin.yml
@@ -1,0 +1,5 @@
+files:
+  - source: /app/src/main/res/values/strings.xml
+    translation: /app/src/main/res/values-%android_code%/%original_file_name%
+    translate_attributes: 0
+    content_segmentation: 0


### PR DESCRIPTION
Fixes # .

Changes in this pull request:
- I looked for places where the Markdown files contained pointers to unfoldingWord's development repositories, as much of that information is either outdated or doesn't apply to our programs.
- The How-to-Contribute article from their wiki is now a Md file in the .github directory, and properly linked from CONTRIBUTING.md
-