### PR TITLE
Revert to api 28

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 
 # Change log
 
+## [1.1.2 (build 8)](https://github.com/Bible-Translation-Tools/BTT-Writer-Android/releases)
+
+- Reverted back to API 28 to temporarily fix issues with newer devices.
+
 ## [1.1.1 (build 7)](https://github.com/Bible-Translation-Tools/BTT-Writer-Android/releases)
 
 - Updated Android SDK target to 29 for Google Play Store compatibility.

--- a/README.md
+++ b/README.md
@@ -15,8 +15,6 @@ Then fork this repository and clone your fork. After the repository has been clo
 
 API 15 is currently the standard minimum sdk version so it is likely you will have it once [Android Studio] has been installed. If not then you will need to download it following the instructions in [Adding SDK Packages].
 
-For more information please read the [wiki].
-
 ## Building
 This application relies on several native libraries. Therefore when building for a device or emulator you must choose the correct build varient for that platform. In Android Studio you can change the build varients by clicking on the `Build Variants` tab in the lower left corner of the IDE window. This will display an embeded window in which you can choose the correct build variant for the `app` module.
 
@@ -28,4 +26,3 @@ In most cases you should use the `x86Debug` variant for emulators and the `fatDe
 [Genymotion]:http://www.genymotion.com/
 [Android Studio]:https://developer.android.com/sdk/installing/studio.html
 [Code Style Guidelines]:https://source.android.com/source/code-style.html
-[wiki]:https://github.com/unfoldingWord-dev/ts-android/wiki

--- a/README.md
+++ b/README.md
@@ -13,6 +13,10 @@ First make sure you have all the dependencies installed
 
 Then fork this repository and clone your fork. After the repository has been cloned to your computer create a new Genymotion emulator. These emulators are faster and have better features that the stock emulators that come with the Androd SDK. As always a physical device will provide the best experience if you have one.
 
+API 15 is currently the standard minimum sdk version so it is likely you will have it once [Android Studio] has been installed. If not then you will need to download it following the instructions in [Adding SDK Packages].
+
+For more information please read the [wiki].
+
 ## Building
 This application relies on several native libraries. Therefore when building for a device or emulator you must choose the correct build varient for that platform. In Android Studio you can change the build varients by clicking on the `Build Variants` tab in the lower left corner of the IDE window. This will display an embeded window in which you can choose the correct build variant for the `app` module.
 
@@ -24,3 +28,4 @@ In most cases you should use the `x86Debug` variant for emulators and the `fatDe
 [Genymotion]:http://www.genymotion.com/
 [Android Studio]:https://developer.android.com/sdk/installing/studio.html
 [Code Style Guidelines]:https://source.android.com/source/code-style.html
+[wiki]:https://github.com/unfoldingWord-dev/ts-android/wiki

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -25,15 +25,15 @@ android {
             }
         }
     }
-    compileSdkVersion 29
+    compileSdkVersion 28
     defaultConfig {
         applicationId "org.bibletranslationtools.writer.android"
         minSdkVersion 15
-        targetSdkVersion 29
-        versionCode 7
-        versionName "1.1.1"
+        targetSdkVersion 28
+        versionCode 8
+        versionName "1.1.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
-    }
+    } 
     buildTypes {
         release {
             minifyEnabled true

--- a/html-textview/build.gradle
+++ b/html-textview/build.gradle
@@ -1,10 +1,10 @@
 apply plugin: 'com.android.library'
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 7
-        targetSdkVersion 29
+        targetSdkVersion 28
     }
 
     // Do not abort build if lint finds errors

--- a/seekbarhint/build.gradle
+++ b/seekbarhint/build.gradle
@@ -2,11 +2,11 @@ apply plugin: 'com.android.library'
 //apply plugin: 'com.github.dcendents.android-maven'
 
 android {
-    compileSdkVersion 29
+    compileSdkVersion 28
 
     defaultConfig {
         minSdkVersion 15
-        targetSdkVersion 29
+        targetSdkVersion 28
         versionCode 1
         versionName "1.0.1"
     }


### PR DESCRIPTION
Reverts the API level back to 28 so that BTT-Writer can continue to work on newer devices.