### PR TITLE
Fix timeout error on updating sources and languages

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -103,11 +103,17 @@ dependencies {
     implementation 'org.apmem.tools:layouts:1.10'
     implementation 'com.itextpdf:itextpdf:5.5.10'
     implementation 'com.facebook.rebound:rebound:0.3.8'
-    implementation 'org.unfoldingword.tools:gogs-client:1.6.1'
+    implementation('org.unfoldingword.tools:gogs-client:1.6.1') {
+        exclude group: 'org.unfoldingword.tools', module: 'http'
+    }
     implementation 'org.unfoldingword.tools:task-manager:1.5.3'
-    implementation 'org.unfoldingword.tools:door43-client:0.10.3'
-    implementation 'org.unfoldingword.tools:http:2.4.2'
-    implementation 'org.unfoldingword.tools:logger:2.0.0'
+    implementation('org.unfoldingword.tools:door43-client:0.10.3') {
+        exclude group: 'org.unfoldingword.tools', module: 'http'
+    }
+    //implementation 'org.unfoldingword.tools:http:2.4.2'
+    implementation('org.unfoldingword.tools:logger:2.0.0') {
+        exclude group: 'org.unfoldingword.tools', module: 'http'
+    }
     implementation 'org.unfoldingword.tools:event-buffer:1.0.2'
     implementation 'org.unfoldingword.tools:foreground:0.1.0'
     implementation project(':html-textview')

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "org.bibletranslationtools.writer.android"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 9
-        versionName "1.1.3"
+        versionCode 10
+        versionName "1.1.4"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     } 
     buildTypes {
@@ -110,7 +110,6 @@ dependencies {
     implementation('org.unfoldingword.tools:door43-client:0.10.3') {
         exclude group: 'org.unfoldingword.tools', module: 'http'
     }
-    //implementation 'org.unfoldingword.tools:http:2.4.2'
     implementation('org.unfoldingword.tools:logger:2.0.0') {
         exclude group: 'org.unfoldingword.tools', module: 'http'
     }

--- a/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
@@ -1,0 +1,24 @@
+package org.unfoldingword.tools.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Implements a delete request
+ */
+public class DeleteRequest extends Request {
+
+    /**
+     * Creates a new delete request
+     * @param url the url that will receive the delete request
+     */
+    public DeleteRequest(URL url) {
+        super(url, "DELETE");
+    }
+
+    @Override
+    protected void onConnected(HttpURLConnection conn) throws IOException {
+
+    }
+}

--- a/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
@@ -1,6 +1,6 @@
 package org.unfoldingword.tools.http;
 
-/* Source: https://github.com/unfoldingWord-dev/android-http */
+/* Source: https://github.com/unfoldingWord-dev/android-http/tree/2.4.2 */
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/DeleteRequest.java
@@ -1,5 +1,7 @@
 package org.unfoldingword.tools.http;
 
+/* Source: https://github.com/unfoldingWord-dev/android-http */
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
@@ -1,6 +1,6 @@
 package org.unfoldingword.tools.http;
 
-/* Source: https://github.com/unfoldingWord-dev/android-http */
+/* Source: https://github.com/unfoldingWord-dev/android-http/tree/2.4.2 */
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
@@ -1,5 +1,7 @@
 package org.unfoldingword.tools.http;
 
+/* Source: https://github.com/unfoldingWord-dev/android-http */
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/GetRequest.java
@@ -1,0 +1,20 @@
+package org.unfoldingword.tools.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Implements a get request
+ */
+public class GetRequest extends Request {
+
+    public GetRequest(URL url) {
+        super(url, "GET");
+    }
+
+    @Override
+    protected void onConnected(HttpURLConnection conn) throws IOException {
+
+    }
+}

--- a/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
@@ -1,6 +1,6 @@
 package org.unfoldingword.tools.http;
 
-/* Source: https://github.com/unfoldingWord-dev/android-http */
+/* Source: https://github.com/unfoldingWord-dev/android-http/tree/2.4.2 */
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
@@ -1,0 +1,27 @@
+package org.unfoldingword.tools.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Implements a post request
+ */
+public class PostRequest extends Request {
+    private final String data;
+
+    /**
+     * Creates a new post request
+     * @param url the url receiving the post request
+     * @param data the post data
+     */
+    public PostRequest(URL url, String data) {
+        super(url, "POST");
+        this.data = data;
+    }
+
+    @Override
+    protected void onConnected(HttpURLConnection conn) throws IOException {
+        writeData(conn, data);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PostRequest.java
@@ -1,5 +1,7 @@
 package org.unfoldingword.tools.http;
 
+/* Source: https://github.com/unfoldingWord-dev/android-http */
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
@@ -1,6 +1,6 @@
 package org.unfoldingword.tools.http;
 
-/* Source: https://github.com/unfoldingWord-dev/android-http */
+/* Source: https://github.com/unfoldingWord-dev/android-http/tree/2.4.2 */
 
 import java.io.IOException;
 import java.net.HttpURLConnection;

--- a/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
@@ -1,0 +1,27 @@
+package org.unfoldingword.tools.http;
+
+import java.io.IOException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+/**
+ * Implements a put request
+ */
+public class PutRequest extends Request {
+    private final String data;
+
+    /**
+     * Creates a new put request
+     * @param url the url receiving the put request
+     * @param data the put data
+     */
+    public PutRequest(URL url, String data) {
+        super(url, "PUT");
+        this.data = data;
+    }
+
+    @Override
+    protected void onConnected(HttpURLConnection conn) throws IOException {
+        writeData(conn, data);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/PutRequest.java
@@ -1,5 +1,7 @@
 package org.unfoldingword.tools.http;
 
+/* Source: https://github.com/unfoldingWord-dev/android-http */
+
 import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.net.URL;

--- a/app/src/main/java/org/unfoldingword/tools/http/Request.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/Request.java
@@ -1,5 +1,7 @@
 package org.unfoldingword.tools.http;
 
+/* Source: https://github.com/unfoldingWord-dev/android-http */
+
 import android.util.Base64;
 
 import java.io.BufferedInputStream;
@@ -36,7 +38,6 @@ public abstract class Request {
     public Request(URL url, String requestMethod) {
         this.url = url;
         this.requestMethod = requestMethod.toUpperCase();
-        System.out.println("GREETINGS FRIEND, ttl=" + ttl);
     }
 
     /**

--- a/app/src/main/java/org/unfoldingword/tools/http/Request.java
+++ b/app/src/main/java/org/unfoldingword/tools/http/Request.java
@@ -1,0 +1,311 @@
+package org.unfoldingword.tools.http;
+
+import android.util.Base64;
+
+import java.io.BufferedInputStream;
+import java.io.ByteArrayOutputStream;
+import java.io.DataOutputStream;
+import java.io.File;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.UnsupportedEncodingException;
+import java.net.HttpURLConnection;
+import java.net.URL;
+
+import javax.net.ssl.HttpsURLConnection;
+
+/**
+ * Represents a network request
+ */
+public abstract class Request {
+    private final URL url;
+    private final String requestMethod;
+    private String auth = null;
+    private String contentType = null;
+    private int responseCode = -1;
+    private String responseMessage = null;
+    private int ttl = 30000;
+    private OnProgressListener progressListener = null;
+
+    /**
+     * Prepare a new network request
+     * @param url The url that will receive the request
+     * @param requestMethod the method of request e.g. POST, GET, PUT, etc.
+     */
+    public Request(URL url, String requestMethod) {
+        this.url = url;
+        this.requestMethod = requestMethod.toUpperCase();
+        System.out.println("GREETINGS FRIEND, ttl=" + ttl);
+    }
+
+    /**
+     * Sets the authentication token for the request.
+     * The auth label will be "Bearer". Use {@link #setAuth(String, String)} to customize the label.
+     * @param token
+     */
+    public void setAuth(String token) {
+        setAuth(token, "Bearer");
+    }
+
+    /**
+     * Sets the authentication for the request
+     * @param token
+     * @param label the auth label
+     */
+    public void setAuth(String token, String label) {
+        this.auth = label + " " + token;
+    }
+
+    /**
+     * Sets the username and password used for authenticating the request.
+     * @param username
+     * @param password
+     */
+    public void setCredentials(String username, String password) throws UnsupportedEncodingException {
+        String credentials = username + ":" + password;
+        String token = Base64.encodeToString(credentials.getBytes("UTF-8"), Base64.NO_WRAP);
+        setAuth(token, "Basic");
+    }
+
+    /**
+     * Sets the connection write and read timeout
+     * @param ttl the time allowed before the connection times out
+     */
+    public void setTimeout(int ttl) {
+        this.ttl = ttl;
+    }
+
+    /**
+     * Sets the listener to receive progress updates
+     * @param listener a listener that will receive progress events
+     */
+    public void setProgressListener(OnProgressListener listener) {
+        this.progressListener = listener;
+    }
+
+    /**
+     * Sets the token used for authenticating the post request
+     * Tokens take precedence over credentials
+     * Token authentication.
+     * @deprecated use {@link #setAuth(String)} instead
+     * @param token the authentication token
+     */
+    public void setAuthentication(String token) {
+        setAuth(token, "token");
+    }
+
+    /**
+     * Sets the credentials used for authenticating the report
+     * Basic authentication.
+     * @deprecated use {@link #setCredentials(String, String)} instead
+     * @param username the username to be authenticated as
+     * @param password the password to authenticate with
+     */
+    public void setAuthentication(String username, String password) {
+        try {
+            setCredentials(username, password);
+        } catch (UnsupportedEncodingException e) {
+            e.printStackTrace();
+            auth = null;
+        }
+    }
+
+    /**
+     * Sets the content type to be used in the request
+     * @param contentType the content type of the request
+     */
+    public void setContentType(String contentType) {
+        this.contentType = contentType;
+    }
+
+    /**
+     * Creates a new connection object
+     * @return a connection object
+     * @throws IOException
+     */
+    protected HttpURLConnection openConnection() throws IOException {
+        HttpURLConnection conn;
+        if(url.getProtocol().equals("https")) {
+            conn = (HttpsURLConnection)url.openConnection();
+        } else {
+            conn = (HttpURLConnection)url.openConnection();
+        }
+        if(this.auth != null) {
+            conn.setRequestProperty("Authorization", this.auth);
+        }
+        if(contentType != null) {
+            conn.setRequestProperty("Content-Type", contentType);
+        }
+        conn.setRequestMethod(requestMethod);
+        conn.setConnectTimeout(ttl);
+        conn.setReadTimeout(ttl);
+
+        try {
+            onConnected(conn);
+        } catch (IOException e) {
+            throw e;
+        } finally {
+            responseCode = conn.getResponseCode();
+            responseMessage = conn.getResponseMessage();
+        }
+
+        return conn;
+    }
+
+    /**
+     * Submits data to the connection.
+     * Such as in a POST or PUT request.
+     * @param connection the connection that will receive the data
+     * @param data the data to be sent
+     * @throws IOException
+     */
+    protected void writeData(HttpURLConnection connection, String data) throws IOException {
+        connection.setDoOutput(true);
+        DataOutputStream dos = new DataOutputStream(connection.getOutputStream());
+        dos.writeBytes(data);
+        dos.flush();
+        dos.close();
+    }
+
+    /**
+     * Downloads the response to a file
+     * @param destination the file where the response will be downloaded to
+     * @throws IOException
+     */
+    public final void download(File destination) throws IOException {
+        HttpURLConnection connection = openConnection();
+
+        int responseSize = connection.getContentLength();
+
+        destination.getParentFile().mkdirs();
+        FileOutputStream out = new FileOutputStream(destination);
+
+        int updateInterval = 1048 * 50; // send an update each time some bytes have been downloaded
+        int updateQueue = 0;
+        int bytesRead = 0;
+
+        InputStream in = null;
+        try {
+            in = new BufferedInputStream(connection.getInputStream());
+            byte[] buffer = new byte[4096];
+            int n = 0;
+            while ((n = in.read(buffer)) != -1) {
+                bytesRead += n;
+                updateQueue += n;
+                out.write(buffer, 0, n);
+
+                // send updates
+                if (updateQueue >= updateInterval) {
+                    updateQueue = 0;
+                    publishProgress(responseSize, bytesRead);
+                }
+            }
+            publishProgress(responseSize, bytesRead);
+        } catch (Exception e) {
+            if(in != null) in.close();
+            out.close();
+            connection.disconnect();
+            if(destination.exists()) destination.delete();
+            throw e;
+        }
+
+        if(in != null) in.close();
+        out.close();
+        connection.disconnect();
+    }
+
+    /**
+     * Reads the response as a string
+     * @return the response string
+     * @throws IOException
+     */
+    public final String read() throws IOException {
+        HttpURLConnection connection = openConnection();
+
+        int responseSize = connection.getContentLength();
+        ByteArrayOutputStream out = new ByteArrayOutputStream();
+
+        int updateInterval = 1048 * 50; // send an update each time some bytes have been downloaded
+        int updateQueue = 0;
+        int bytesRead = 0;
+
+        BufferedInputStream in = null;
+        try {
+            in = new BufferedInputStream(connection.getInputStream());
+            int n = 0;
+            while ((n = in.read()) != -1) {
+                out.write((byte) n);
+
+                // send updates
+                if (updateQueue >= updateInterval) {
+                    updateQueue = 0;
+                    publishProgress(responseSize, bytesRead);
+                }
+
+            }
+            publishProgress(responseSize, bytesRead);
+        } catch (Exception e) {
+            throw e;
+        } finally {
+            if(in != null) in.close();
+            out.close();
+            connection.disconnect();
+        }
+
+        return out.toString("UTF-8");
+    }
+
+    /**
+     * Sends notifications to the progress listener
+     * @param totalBytes the total size of the payload
+     * @param bytesRead the number of bytes read
+     */
+    private void publishProgress(long totalBytes, long bytesRead) {
+        if(progressListener == null) return;
+        if(totalBytes <= 0 || bytesRead <= 0) {
+            progressListener.onIndeterminate();
+        } else {
+            progressListener.onProgress(totalBytes, bytesRead);
+        }
+
+    }
+
+    /**
+     * Returns the response code for this request
+     * @return the request response code
+     */
+    public int getResponseCode() {
+        return responseCode;
+    }
+
+    /**
+     * Returns the error message for this request
+     * @return an error message
+     */
+    public String getResponseMessage() {
+        return responseMessage;
+    }
+
+    /**
+     * Allows subclasses to perform operations afer the connection has been opened.
+     * For example: writing data to the connection.
+     *
+     * @throws IOException
+     */
+    protected abstract void onConnected(HttpURLConnection conn) throws IOException;
+
+    public interface OnProgressListener {
+        /**
+         * Receives progress events
+         * @param max the total number of items being processed
+         * @param progress the number of items that have been successfully processed
+         */
+        void onProgress(long max, long progress);
+
+        /**
+         * Receives a notice that the progresss is indeterminate
+         */
+        void onIndeterminate();
+    }
+}


### PR DESCRIPTION
This PR fixes a timeout issue when updating sources and languages on slow connections.  It raises the TTL from 5s to 30s.  

The TTL is set in the underlying library unfoldingword.tools.http.  Unfortunately the TTL is not configurable within the library, so for now I have replaced the dependency with a slightly modified version of the library.

- Remove existing library unfoldingword.tools.http:2.4.2 from dependencies list.
- Exclude indirect dependencies from other libraries.
- Add a copy of unfoldingword.tools.http:2.4.2 to this source tree.
- Modify our copy to increase the TTL from 5s to 30s.
- Update version number and version code.