### PR TITLE
Replace Account Creation form with link

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "org.bibletranslationtools.writer.android"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 10
-        versionName "1.1.4"
+        versionCode 11
+        versionName "1.1.5"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     } 
     buildTypes {

--- a/app/src/main/java/com/door43/translationstudio/ui/ProfileActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/ProfileActivity.java
@@ -3,6 +3,7 @@ package com.door43.translationstudio.ui;
 import android.app.Activity;
 import android.content.DialogInterface;
 import android.content.Intent;
+import android.net.Uri;
 import android.os.Bundle;
 import androidx.appcompat.app.AlertDialog;
 import android.view.MenuItem;
@@ -37,7 +38,13 @@ public class ProfileActivity extends BaseActivity {
         registerDoor43.setOnClickListener(new View.OnClickListener() {
             @Override
             public void onClick(View v) {
-                Intent intent = new Intent(ProfileActivity.this, RegisterDoor43Activity.class);
+                String defaultAccountCreateUrl = App.context().getResources().getString(
+                        R.string.pref_default_create_account_url);
+                String accountCreateUrl = App.context().getUserPreferences().getString(
+                        SettingsActivity.KEY_PREF_CREATE_ACCOUNT_URL,
+                        defaultAccountCreateUrl);
+                Uri uri = Uri.parse(accountCreateUrl);
+                Intent intent = new Intent(Intent.ACTION_VIEW, uri);
                 startActivity(intent);
             }
         });

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -67,7 +68,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
      * as a master/detail two-pane view on tablets. When true, a single pane is
      * shown on tablets.
      */
-    private static final boolean ALWAYS_SIMPLE_PREFS = false;
+    private static final boolean ALWAYS_SIMPLE_PREFS = true;
 //    public static final String KEY_PREF_AUTOSAVE = "autosave";
     public static final String KEY_PREF_CONTENT_SERVER = "content_server";
     public static final String KEY_PREF_GIT_SERVER = "git_server";
@@ -264,11 +265,12 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             e.printStackTrace();
         }
 
-        Preference gitServer = findPreference(KEY_PREF_CONTENT_SERVER);
+        final Preference gitServer = findPreference(KEY_PREF_CONTENT_SERVER);
         gitServer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
             @Override
             public boolean onPreferenceChange(Preference preference, Object value) {
                 String newValue = (String) value;
+                System.out.println("Simple onPreferenceChange() newValue:" + newValue);
                 String[] values = getResources().getStringArray(R.array.content_server_values_array);
                 String[] serverNames = getResources().getStringArray(R.array.content_server_names_array);
                 int index = Arrays.asList(values).indexOf(newValue);
@@ -582,36 +584,39 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
                     if (s.equals(KEY_PREF_CONTENT_SERVER)) {
 
+                        final Resources resources = getResources();
+
                         String newValue = sharedPreferences.getString(KEY_PREF_CONTENT_SERVER, "");
-                        String[] values = getResources().getStringArray(R.array.content_server_values_array);
+                        System.out.println("Fragment onSharedPreferenceChanged() newValue:" + newValue);
+                        String[] values = resources.getStringArray(R.array.content_server_values_array);
                         int index = Arrays.asList(values).indexOf(newValue);
 
-                        String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
+                        String[] gitServers = resources.getStringArray(R.array.content_server_git_server_values_array);
                         EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
                         gitServer.setText(gitServers[index]);
                         gitServer.setSummary(gitServers[index]);
 
-                        String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
+                        String[] gitServerPorts = resources.getStringArray(R.array.content_server_git_server_port_values_array);
                         EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
                         gitServerPort.setText(gitServerPorts[index]);
                         gitServerPort.setSummary(gitServerPorts[index]);
 
-                        String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
+                        String[] gitServerApis = resources.getStringArray(R.array.content_server_git_server_api_values_array);
                         EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
                         gitServerApi.setText(gitServerApis[index]);
                         gitServerApi.setSummary(gitServerApis[index]);
 
-                        String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
+                        String[] mediaServers = resources.getStringArray(R.array.content_server_media_server_values_array);
                         EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
                         mediaServer.setText(mediaServers[index]);
                         mediaServer.setSummary(mediaServers[index]);
 
-                        String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
+                        String[] readerServers = resources.getStringArray(R.array.content_server_reader_server_values_array);
                         EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
                         readerServer.setText(readerServers[index]);
                         readerServer.setSummary(readerServers[index]);
 
-                        String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
+                        String[] createAccountUrls = resources.getStringArray(R.array.content_server_account_create_urls_array);
                         EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
                         createAccountUrl.setText(createAccountUrls[index]);
                         createAccountUrl.setSummary(createAccountUrls[index]);

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -75,6 +75,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
     public static final String KEY_PREF_ALWAYS_SHARE = "always_share";
     public static final String KEY_PREF_MEDIA_SERVER = "media_server";
     public static final String KEY_PREF_READER_SERVER = "reader_server";
+    public static final String KEY_PREF_CREATE_ACCOUNT_URL = "create_account_url";
 //    public static final String KEY_PREF_EXPORT_FORMAT = "export_format";
     public static final String KEY_PREF_TRANSLATION_TYPEFACE = "translation_typeface";
     public static final String KEY_PREF_TRANSLATION_TYPEFACE_SIZE = "typeface_size";
@@ -251,6 +252,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
 //        bindPreferenceSummaryToValue(findPreference(KEY_PREF_EXPORT_FORMAT));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
+        bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_LOGGING_LEVEL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_BACKUP_INTERVAL));
 
@@ -562,6 +564,11 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                         EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
                         readerServer.setText(readerServers[index]);
                         readerServer.setSummary(readerServers[index]);
+
+                        String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
+                        EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
+                        createAccountUrl.setText(createAccountUrls[index]);
+                        createAccountUrl.setSummary(createAccountUrls[index]);
                     }
                 }
             });
@@ -577,6 +584,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_GIT_SERVER_PORT));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
+            bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
 
             initSettings = false;
         }

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -11,6 +11,7 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
+import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -269,39 +270,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             @Override
             public boolean onPreferenceChange(Preference preference, Object value) {
                 String newValue = (String) value;
-                String[] values = getResources().getStringArray(R.array.content_server_values_array);
-                int index = Arrays.asList(values).indexOf(newValue);
-
-                String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
-                EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
-                gitServer.setText(gitServers[index]);
-                gitServer.setSummary(gitServers[index]);
-
-                String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
-                EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
-                gitServerPort.setText(gitServerPorts[index]);
-                gitServerPort.setSummary(gitServerPorts[index]);
-
-                String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
-                EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
-                gitServerApi.setText(gitServerApis[index]);
-                gitServerApi.setSummary(gitServerApis[index]);
-
-                String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
-                EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
-                mediaServer.setText(mediaServers[index]);
-                mediaServer.setSummary(mediaServers[index]);
-
-                String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
-                EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
-                readerServer.setText(readerServers[index]);
-                readerServer.setSummary(readerServers[index]);
-
-                String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
-                EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
-                createAccountUrl.setText(createAccountUrls[index]);
-                createAccountUrl.setSummary(createAccountUrls[index]);
-
+                setAllServerPreferences(newValue);
                 return true;
             }
         });
@@ -560,6 +529,50 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
 
             initSettings = false;
         }
+    }
+
+    /**
+     * Sets all server preferences based on the value of newValue, which should
+     * be one of the values in R.array.content_server_values_array.
+     * @param newValue
+     */
+    private void setAllServerPreferences(String newValue) {
+
+        String[] values = getResources().getStringArray(R.array.content_server_values_array);
+        String[] serverNames = getResources().getStringArray(R.array.content_server_names_array);
+        int index = Arrays.asList(values).indexOf(newValue);
+        ListPreference contentServer = (ListPreference) findPreference(KEY_PREF_CONTENT_SERVER);
+        contentServer.setSummary(serverNames[index]);
+
+        String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
+        EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
+        gitServer.setText(gitServers[index]);
+        gitServer.setSummary(gitServers[index]);
+
+        String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
+        EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
+        gitServerPort.setText(gitServerPorts[index]);
+        gitServerPort.setSummary(gitServerPorts[index]);
+
+        String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
+        EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
+        gitServerApi.setText(gitServerApis[index]);
+        gitServerApi.setSummary(gitServerApis[index]);
+
+        String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
+        EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
+        mediaServer.setText(mediaServers[index]);
+        mediaServer.setSummary(mediaServers[index]);
+
+        String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
+        EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
+        readerServer.setText(readerServers[index]);
+        readerServer.setSummary(readerServers[index]);
+
+        String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
+        EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
+        createAccountUrl.setText(createAccountUrls[index]);
+        createAccountUrl.setSummary(createAccountUrls[index]);
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -264,6 +264,48 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             e.printStackTrace();
         }
 
+        Preference gitServer = findPreference(KEY_PREF_CONTENT_SERVER);
+        gitServer.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object value) {
+                String newValue = (String) value;
+                String[] values = getResources().getStringArray(R.array.content_server_values_array);
+                int index = Arrays.asList(values).indexOf(newValue);
+
+                String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
+                EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
+                gitServer.setText(gitServers[index]);
+                gitServer.setSummary(gitServers[index]);
+
+                String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
+                EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
+                gitServerPort.setText(gitServerPorts[index]);
+                gitServerPort.setSummary(gitServerPorts[index]);
+
+                String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
+                EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
+                gitServerApi.setText(gitServerApis[index]);
+                gitServerApi.setSummary(gitServerApis[index]);
+
+                String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
+                EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
+                mediaServer.setText(mediaServers[index]);
+                mediaServer.setSummary(mediaServers[index]);
+
+                String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
+                EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
+                readerServer.setText(readerServers[index]);
+                readerServer.setSummary(readerServers[index]);
+
+                String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
+                EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
+                createAccountUrl.setText(createAccountUrls[index]);
+                createAccountUrl.setSummary(createAccountUrls[index]);
+
+                return true;
+            }
+        });
+
         findPreference("app_updates").setOnPreferenceClickListener(new Preference.OnPreferenceClickListener() {
             @Override
             public boolean onPreferenceClick(Preference preference) {

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -11,7 +11,6 @@ import android.content.pm.PackageInfo;
 import android.content.pm.PackageManager;
 import android.content.res.AssetManager;
 import android.content.res.Configuration;
-import android.content.res.Resources;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
@@ -270,7 +269,42 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             @Override
             public boolean onPreferenceChange(Preference preference, Object value) {
                 String newValue = (String) value;
-                setAllServerPreferences(newValue);
+                String[] values = getResources().getStringArray(R.array.content_server_values_array);
+                String[] serverNames = getResources().getStringArray(R.array.content_server_names_array);
+                int index = Arrays.asList(values).indexOf(newValue);
+                ListPreference contentServer = (ListPreference) findPreference(KEY_PREF_CONTENT_SERVER);
+                contentServer.setSummary(serverNames[index]);
+
+                String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
+                EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
+                gitServer.setText(gitServers[index]);
+                gitServer.setSummary(gitServers[index]);
+
+                String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
+                EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
+                gitServerPort.setText(gitServerPorts[index]);
+                gitServerPort.setSummary(gitServerPorts[index]);
+
+                String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
+                EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
+                gitServerApi.setText(gitServerApis[index]);
+                gitServerApi.setSummary(gitServerApis[index]);
+
+                String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
+                EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
+                mediaServer.setText(mediaServers[index]);
+                mediaServer.setSummary(mediaServers[index]);
+
+                String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
+                EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
+                readerServer.setText(readerServers[index]);
+                readerServer.setSummary(readerServers[index]);
+
+                String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
+                EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
+                createAccountUrl.setText(createAccountUrls[index]);
+                createAccountUrl.setSummary(createAccountUrls[index]);
+
                 return true;
             }
         });
@@ -532,50 +566,6 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
     }
 
     /**
-     * Sets all server preferences based on the value of newValue, which should
-     * be one of the values in R.array.content_server_values_array.
-     * @param newValue
-     */
-    private void setAllServerPreferences(String newValue) {
-
-        String[] values = getResources().getStringArray(R.array.content_server_values_array);
-        String[] serverNames = getResources().getStringArray(R.array.content_server_names_array);
-        int index = Arrays.asList(values).indexOf(newValue);
-        ListPreference contentServer = (ListPreference) findPreference(KEY_PREF_CONTENT_SERVER);
-        contentServer.setSummary(serverNames[index]);
-
-        String[] gitServers = getResources().getStringArray(R.array.content_server_git_server_values_array);
-        EditTextPreference gitServer = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER);
-        gitServer.setText(gitServers[index]);
-        gitServer.setSummary(gitServers[index]);
-
-        String[] gitServerPorts = getResources().getStringArray(R.array.content_server_git_server_port_values_array);
-        EditTextPreference gitServerPort = (EditTextPreference) findPreference(KEY_PREF_GIT_SERVER_PORT);
-        gitServerPort.setText(gitServerPorts[index]);
-        gitServerPort.setSummary(gitServerPorts[index]);
-
-        String[] gitServerApis = getResources().getStringArray(R.array.content_server_git_server_api_values_array);
-        EditTextPreference gitServerApi = (EditTextPreference) findPreference(KEY_PREF_GOGS_API);
-        gitServerApi.setText(gitServerApis[index]);
-        gitServerApi.setSummary(gitServerApis[index]);
-
-        String[] mediaServers = getResources().getStringArray(R.array.content_server_media_server_values_array);
-        EditTextPreference mediaServer = (EditTextPreference) findPreference(KEY_PREF_MEDIA_SERVER);
-        mediaServer.setText(mediaServers[index]);
-        mediaServer.setSummary(mediaServers[index]);
-
-        String[] readerServers = getResources().getStringArray(R.array.content_server_reader_server_values_array);
-        EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
-        readerServer.setText(readerServers[index]);
-        readerServer.setSummary(readerServers[index]);
-
-        String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
-        EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
-        createAccountUrl.setText(createAccountUrls[index]);
-        createAccountUrl.setSummary(createAccountUrls[index]);
-    }
-
-    /**
      * This fragment shows save preferences only. It is used when the
      * activity is showing a two-pane settings UI.
      */
@@ -591,6 +581,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 @Override
                 public void onSharedPreferenceChanged(SharedPreferences sharedPreferences, String s) {
                     if (s.equals(KEY_PREF_CONTENT_SERVER)) {
+
                         String newValue = sharedPreferences.getString(KEY_PREF_CONTENT_SERVER, "");
                         String[] values = getResources().getStringArray(R.array.content_server_values_array);
                         int index = Arrays.asList(values).indexOf(newValue);

--- a/app/src/main/res/values/servers.xml
+++ b/app/src/main/res/values/servers.xml
@@ -35,4 +35,9 @@
         <item>http://read.bibletranslationtools.org/u</item>
         <item>https://door43.org/u</item>
     </string-array>
+
+    <string-array name="content_server_account_create_urls_array">
+        <item>https://content.bibletranslationtools.org/user/sign_up</item>
+        <item>https://git.door43.org/user/sign_up</item>
+    </string-array>
 </resources>

--- a/app/src/main/res/values/strings_user_pref.xml
+++ b/app/src/main/res/values/strings_user_pref.xml
@@ -52,6 +52,8 @@
     <string name="pref_title_media_server">Media Server</string>
     <!-- The server used to review translation work in reader -->
     <string name="pref_title_reader_server">Reader Server</string>
+    <!-- The URL to create a new account. -->
+    <string name="pref_title_create_account_url">Account Creation URL</string>
 
     <!-- Section heading for Sharing settings -->
     <!--<string name="pref_header_sharing" translatable="false">Sharing</string>-->

--- a/app/src/main/res/values/strings_user_pref_values.xml
+++ b/app/src/main/res/values/strings_user_pref_values.xml
@@ -33,6 +33,8 @@
 
     <string name="pref_default_reader_server" translatable="false">http://read.bibletranslationtools.org/u</string>
 
+    <string name="pref_default_create_account_url" translatable="false">https://content.bibletranslationtools.org/user/sign_up</string>
+
     <!--<string name="pref_default_export_format" translatable="false">dokuwiki</string>-->
     <!--<string-array name="pref_export_format_values" translatable="false">-->
         <!--<item>dokuwiki</item>-->

--- a/app/src/main/res/xml/server_preferences.xml
+++ b/app/src/main/res/xml/server_preferences.xml
@@ -47,4 +47,9 @@
         android:key="reader_server"
         android:title="@string/pref_title_reader_server"
         android:defaultValue="@string/pref_default_reader_server"/>
+
+    <EditTextPreference
+        android:key="create_account_url"
+        android:title="@string/pref_title_create_account_url"
+        android:defaultValue="@string/pref_default_create_account_url"/>
 </PreferenceScreen>


### PR DESCRIPTION
This PR changes the behavior of the "Create New Server Account" button in the Profile Activity.  Instead of opening the create user form, it will now open the user's default browser to the server account creation page.  This page is configurable, and comes with default values for WACS and DCS.

This is necessary because of changes to how Gitea manages the account creation process.  The way the BW previously created accounts now results in a confusing message and a frustrating workflow.  This change now directs the user to the server to create their account, which they can then use to log in to BTT-Writer.