### PR TITLE
Fix profile screen issues

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,8 +30,8 @@ android {
         applicationId "org.bibletranslationtools.writer.android"
         minSdkVersion 15
         targetSdkVersion 28
-        versionCode 11
-        versionName "1.1.5"
+        versionCode 12
+        versionName "1.1.7"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
     } 
     buildTypes {

--- a/app/src/main/java/com/door43/translationstudio/ui/SplashScreenActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SplashScreenActivity.java
@@ -53,12 +53,7 @@ public class SplashScreenActivity extends BaseActivity implements ManagedTask.On
             int numProcessors = Runtime.getRuntime().availableProcessors();
             long maxMem = Runtime.getRuntime().maxMemory();
 
-            int screenMask = getResources().getConfiguration().screenLayout & Configuration.SCREENLAYOUT_SIZE_MASK;
-            boolean smallScreen = (screenMask == Configuration.SCREENLAYOUT_SIZE_SMALL
-                                    || screenMask == Configuration.SCREENLAYOUT_SIZE_NORMAL
-                                    || screenMask == Configuration.SCREENLAYOUT_SIZE_UNDEFINED);
-
-            if (numProcessors < App.minimumNumberOfProcessors || maxMem < App.minimumRequiredRAM || smallScreen) {
+            if (numProcessors < App.minimumNumberOfProcessors || maxMem < App.minimumRequiredRAM) {
                 silentStart = false;
                 new AlertDialog.Builder(this, R.style.AppTheme_Dialog)
                         .setTitle(R.string.slow_device)

--- a/app/src/main/res/layout-land/activity_profile.xml
+++ b/app/src/main/res/layout-land/activity_profile.xml
@@ -7,7 +7,7 @@
     tools:context=".ui.ProfileActivity">
 
     <LinearLayout
-        android:orientation="vertical"
+        android:orientation="horizontal"
         android:layout_width="match_parent"
         android:layout_height="match_parent">
 


### PR DESCRIPTION
This PR contains the following changes:

- Fix problem where the profile screen wouldn't load correctly in portrait mode.  (Fixed by creating separate layouts for portrait and landscape.)
- Remove misleading "slow device" warning for small screens
- Bump version