### PR TITLE
Unselected source translations will be removed from manifest

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
@@ -467,6 +467,22 @@ public class TargetTranslation {
         }
     }
 
+    public void updateSourceTranslations(Map<Translation, Integer> translations) throws JSONException {
+        JSONArray sourcesJson = new JSONArray();
+
+        for (Map.Entry<Translation, Integer> entry : translations.entrySet()) {
+            Translation src = entry.getKey();
+            JSONObject translationJson = new JSONObject();
+            translationJson.put("language_id", src.language.slug);
+            translationJson.put("resource_id", src.resource.slug);
+            translationJson.put("checking_level", src.resource.checkingLevel);
+            translationJson.put("date_modified", entry.getValue());
+            translationJson.put("version", src.resource.version);
+            sourcesJson.put(translationJson);
+            manifest.put(FIELD_SOURCE_TRANSLATIONS, sourcesJson);
+        }
+    }
+
     /**
      * cleanup in case we have duplicates in the list
      * @param sourceTranslationsJson

--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
@@ -11,7 +11,6 @@ import org.unfoldingword.resourcecontainer.ResourceContainer;
 import org.unfoldingword.door43client.models.TargetLanguage;
 import org.unfoldingword.tools.logger.Logger;
 
-import com.door43.translationstudio.App;
 import com.door43.translationstudio.core.entity.SourceTranslation;
 import com.door43.translationstudio.git.Repo;
 import com.door43.util.NumericStringComparator;
@@ -469,25 +468,12 @@ public class TargetTranslation {
         }
     }
 
+    /**
+     * Sets the list of associated sources for the current target translation.
+     * @param translations the list of source translations
+     * @throws JSONException
+     */
     public void setSourceTranslations(List<SourceTranslation> translations) throws JSONException {
-        String targetTranslationId = getId();
-
-        for (SourceTranslation src : translations) {
-            try {
-                App.addOpenSourceTranslation(targetTranslationId, src.resourceContainerSlug);
-            } catch (Exception e) {
-                Logger.e(
-                    this.getClass().getName(),
-                    "Error while adding source " + src.resourceContainerSlug + " for " + targetTranslationId
-                );
-                e.printStackTrace();
-            }
-        }
-
-        updateSourcesInManifest(translations);
-    }
-
-    private void updateSourcesInManifest(List<SourceTranslation> translations) throws JSONException {
         JSONArray sourcesJson = new JSONArray();
         for (SourceTranslation src : translations) {
             JSONObject translationJson = new JSONObject();

--- a/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
+++ b/app/src/main/java/com/door43/translationstudio/core/TargetTranslation.java
@@ -11,6 +11,8 @@ import org.unfoldingword.resourcecontainer.ResourceContainer;
 import org.unfoldingword.door43client.models.TargetLanguage;
 import org.unfoldingword.tools.logger.Logger;
 
+import com.door43.translationstudio.App;
+import com.door43.translationstudio.core.entity.SourceTranslation;
 import com.door43.translationstudio.git.Repo;
 import com.door43.util.NumericStringComparator;
 import com.door43.util.FileUtilities;
@@ -467,16 +469,32 @@ public class TargetTranslation {
         }
     }
 
-    public void updateSourceTranslations(Map<Translation, Integer> translations) throws JSONException {
-        JSONArray sourcesJson = new JSONArray();
+    public void setSourceTranslations(List<SourceTranslation> translations) throws JSONException {
+        String targetTranslationId = getId();
 
-        for (Map.Entry<Translation, Integer> entry : translations.entrySet()) {
-            Translation src = entry.getKey();
+        for (SourceTranslation src : translations) {
+            try {
+                App.addOpenSourceTranslation(targetTranslationId, src.resourceContainerSlug);
+            } catch (Exception e) {
+                Logger.e(
+                    this.getClass().getName(),
+                    "Error while adding source " + src.resourceContainerSlug + " for " + targetTranslationId
+                );
+                e.printStackTrace();
+            }
+        }
+
+        updateSourcesInManifest(translations);
+    }
+
+    private void updateSourcesInManifest(List<SourceTranslation> translations) throws JSONException {
+        JSONArray sourcesJson = new JSONArray();
+        for (SourceTranslation src : translations) {
             JSONObject translationJson = new JSONObject();
             translationJson.put("language_id", src.language.slug);
             translationJson.put("resource_id", src.resource.slug);
             translationJson.put("checking_level", src.resource.checkingLevel);
-            translationJson.put("date_modified", entry.getValue());
+            translationJson.put("date_modified", src.getModifiedTimestamp());
             translationJson.put("version", src.resource.version);
             sourcesJson.put(translationJson);
             manifest.put(FIELD_SOURCE_TRANSLATIONS, sourcesJson);

--- a/app/src/main/java/com/door43/translationstudio/core/entity/SourceTranslation.java
+++ b/app/src/main/java/com/door43/translationstudio/core/entity/SourceTranslation.java
@@ -1,0 +1,33 @@
+package com.door43.translationstudio.core.entity;
+
+import org.unfoldingword.door43client.models.Translation;
+import org.unfoldingword.resourcecontainer.Language;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+
+public class SourceTranslation extends Translation {
+
+    private int modifiedTimestamp = -1;
+
+    public SourceTranslation(Language language, Project project, Resource resource) {
+        super(language, project, resource);
+    }
+
+    public SourceTranslation(ResourceContainer container) {
+        super(container);
+    }
+
+    public SourceTranslation(Translation translation, int modifiedTimestamp) {
+        super(translation.language, translation.project, translation.resource);
+        this.modifiedTimestamp = modifiedTimestamp;
+    }
+
+    public int getModifiedTimestamp() {
+        return modifiedTimestamp;
+    }
+
+    public void setModifiedTime(int timestamp) {
+        modifiedTimestamp = timestamp;
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/TargetTranslationInfoDialog.java
@@ -36,14 +36,12 @@ import com.door43.translationstudio.ui.dialogs.BackupDialog;
 
 import org.unfoldingword.door43client.Door43Client;
 import org.unfoldingword.door43client.models.TargetLanguage;
-import org.unfoldingword.door43client.models.Translation;
+import org.unfoldingword.resourcecontainer.Project;
 import org.unfoldingword.tools.logger.Logger;
 import org.unfoldingword.tools.taskmanager.ManagedTask;
 import org.unfoldingword.tools.taskmanager.TaskManager;
 
 import java.util.ArrayList;
-import java.util.List;
-
 
 /**
  * Displays detailed information about a target translation
@@ -87,15 +85,14 @@ public class TargetTranslationInfoDialog extends DialogFragment implements Manag
         TextView languageTitleView = (TextView)v.findViewById(R.id.language_title);
         this.progressView = (TextView)v.findViewById(R.id.progress);
 
-        // Load a source translation
-        Translation sourceTranslation;
-        List<Translation> translations = library.index.findTranslations(null, mTargetTranslation.getProjectId(), null, "book", null, App.MIN_CHECKING_LEVEL, -1);
-        if(translations.size() == 0) {
-            Logger.w("TargetTranslationInfoDialog", "Could not find source for target " + mTargetTranslation.getId());
-            dismiss();
-            return v;
+        Project project;
+        String[] existingSources = mTargetTranslation.getSourceTranslations();
+        // Gets an existing source project or default if none selected
+        if(existingSources.length > 0) {
+            String lastSource = existingSources[existingSources.length - 1];
+            project = library.index.getTranslation(lastSource).project;
         } else {
-            sourceTranslation = translations.get(0);
+            project = library.index.getProject(App.getDeviceLanguageCode(), mTargetTranslation.getProjectId(), true);
         }
 
         // set typeface for language
@@ -104,8 +101,8 @@ public class TargetTranslationInfoDialog extends DialogFragment implements Manag
         titleView.setTypeface(typeface, 0);
         languageTitleView.setTypeface(typeface, 0);
 
-        titleView.setText(sourceTranslation.project.name + " - " + mTargetTranslation.getTargetLanguageName());
-        projectTitleView.setText(sourceTranslation.project.name + " (" + sourceTranslation.project.slug + ")");
+        titleView.setText(project.name + " - " + mTargetTranslation.getTargetLanguageName());
+        projectTitleView.setText(project.name + " (" + project.slug + ")");
         languageTitleView.setText(mTargetTranslation.getTargetLanguageName() + " (" + mTargetTranslation.getTargetLanguageId() + ")");
 
         // calculate translation progress

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ViewModeFragment.java
@@ -653,6 +653,16 @@ public abstract class ViewModeFragment extends BaseFragment implements ViewModeA
     private void setSelectedSources(List<String> sourceSlugs, TargetTranslation targetTranslation) {
         List<SourceTranslation> sources = new ArrayList<>();
         for (String slug : sourceSlugs) {
+            try {
+                App.addOpenSourceTranslation(targetTranslation.getId(), slug);
+            } catch (Exception e) {
+                Logger.e(
+                        this.getClass().getName(),
+                        "Error while adding source " + slug + " for " + targetTranslation.getId()
+                );
+                e.printStackTrace();
+            }
+
             Translation translation = mLibrary.index.getTranslation(slug);
             int modifiedAt = mLibrary.getResourceContainerLastModified(
                     translation.language.slug,


### PR DESCRIPTION
When the user selects source translations for a project, the sources will be added to the manifest. However, when the user unselects these sources, they are not removed from the manifest. As a result, the manifest is out of sync and keeps adding up with the "ghost" source translations as the user selects/unselects new sources.

This PR attempts to replace the sources in the manifest with a list of user-selected sources.