### PR TITLE
Fix render issue with <char> tags

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
+++ b/app/src/main/java/com/door43/translationstudio/rendering/USXRenderer.java
@@ -124,6 +124,8 @@ public class USXRenderer extends ClickableRenderingEngine {
 
         out = trimWhitespace(out);
         if(isStopped()) return in;
+        out = removeCharTags(out);
+        if(isStopped()) return in;
         if(!mRenderLinebreaks) {
             out = renderLineBreaks(out);  // TODO: Eventually we may want to convert these to paragraphs.
         }
@@ -670,6 +672,12 @@ public class USXRenderer extends ClickableRenderingEngine {
         } else {
             return "";
         }
+    }
+
+    public CharSequence removeCharTags(CharSequence in) {
+        Pattern pattern = Pattern.compile("</?char[^<>]*>");
+        Matcher matcher = pattern.matcher(in);
+        return matcher.replaceAll("");
     }
 
     /**


### PR DESCRIPTION
Removes all `<char ...></char>` tags when rendering usx. This approach is based on BTT Writer Desktop `removeCharTags()` in `render.js`

![MicrosoftTeams-image (2)](https://user-images.githubusercontent.com/34975907/215184154-c51cf631-6b4d-422f-a2a7-5cc826e21861.png)
