### PR TITLE
Migrate langnames.json

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -107,9 +107,7 @@ dependencies {
         exclude group: 'org.unfoldingword.tools', module: 'http'
     }
     implementation 'org.unfoldingword.tools:task-manager:1.5.3'
-    implementation('org.unfoldingword.tools:door43-client:0.10.3') {
-        exclude group: 'org.unfoldingword.tools', module: 'http'
-    }
+    implementation 'org.unfoldingword.tools:resource-container:0.7.19'
     implementation('org.unfoldingword.tools:logger:2.0.0') {
         exclude group: 'org.unfoldingword.tools', module: 'http'
     }

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -59,6 +59,7 @@ android {
     lintOptions {
         disable 'MissingTranslation'
         disable 'ExtraTranslation'
+        abortOnError false
     }
 }
 

--- a/app/src/main/assets/schema.sqlite
+++ b/app/src/main/assets/schema.sqlite
@@ -1,0 +1,307 @@
+-- ---
+-- Table 'project'
+--
+-- ---
+
+DROP TABLE IF EXISTS `project`;
+
+CREATE TABLE `project` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `name` TEXT NOT NULL,
+  `desc` TEXT NULL DEFAULT NULL,
+  `icon` TEXT NULL DEFAULT NULL,
+  `sort` INTEGER NOT NULL DEFAULT 0,
+  `chunks_url` TEXT NULL DEFAULT NULL,
+  `source_language_id` INTEGER NOT NULL,
+  `category_id` INTEGER NOT NULL DEFAULT 0,
+  UNIQUE (`source_language_id`, `slug`),
+  FOREIGN KEY (source_language_id) REFERENCES `source_language` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'category_name'
+--
+-- ---
+
+DROP TABLE IF EXISTS `category_name`;
+
+CREATE TABLE `category_name` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `source_language_id` INTEGER NOT NULL DEFAULT NUL,
+  `category_id` INTEGER NOT NULL,
+  `name` TEXT NOT NULL,
+  FOREIGN KEY (source_language_id) REFERENCES `source_language` (`id`),
+  FOREIGN KEY (category_id) REFERENCES `category` (`id`) ON DELETE CASCADE,
+  UNIQUE(`source_language_id`, `category_id`)
+);
+
+-- ---
+-- Table 'category'
+--
+-- ---
+
+DROP TABLE IF EXISTS `category`;
+
+CREATE TABLE `category` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `parent_id` INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(`slug`, `parent_id`)
+);
+
+-- ---
+-- Table 'source_language'
+--
+-- ---
+
+DROP TABLE IF EXISTS `source_language`;
+
+CREATE TABLE `source_language` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `name` TEXT NOT NULL,
+  `direction` TEXT NOT NULL DEFAULT ltr,
+  UNIQUE (`slug`)
+);
+
+-- ---
+-- Table 'resource'
+--
+-- ---
+
+DROP TABLE IF EXISTS `resource`;
+
+CREATE TABLE `resource` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `name` TEXT NOT NULL,
+  `type` TEXT NOT NULL,
+  `translate_mode` TEXT NOT NULL,
+  `checking_level` TEXT NOT NULL,
+  `comments` TEXT NULL DEFAULT NULL,
+  `pub_date` DATE NULL DEFAULT NULL,
+  `license` TEXT NULL DEFAULT NULL,
+  `version` TEXT NOT NULL,
+  `project_id` INTEGER NOT NULL,
+  UNIQUE (`project_id`, `slug`),
+  FOREIGN KEY (project_id) REFERENCES `project` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'legacy_resource_info'
+--
+-- ---
+
+DROP TABLE IF EXISTS `legacy_resource_info`;
+
+CREATE TABLE `legacy_resource_info` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `translation_words_assignments_url` TEXT NULL DEFAULT NULL,
+  `resource_id` INTEGER NOT NULL,
+  UNIQUE (`resource_id`),
+  FOREIGN KEY (resource_id) REFERENCES `resource` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'resource_format'
+--
+-- ---
+
+DROP TABLE IF EXISTS `resource_format`;
+
+CREATE TABLE `resource_format` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `package_version` TEXT NOT NULL,
+  `mime_type` TEXT NOT NULL,
+  `modified_at` INTEGER NOT NULL DEFAULT 0,
+  `imported` INTEGER NOT NULL DEFAULT 0,
+  `url` TEXT NOT NULL,
+  `resource_id` INTEGER NOT NULL,
+  UNIQUE (`mime_type`, `resource_id`),
+  FOREIGN KEY (resource_id) REFERENCES `resource` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'questionnaire'
+--
+-- ---
+
+DROP TABLE IF EXISTS `questionnaire`;
+
+CREATE TABLE `questionnaire` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `language_slug` TEXT NOT NULL,
+  `language_name` TEXT NOT NULL,
+  `language_direction` TEXT NOT NULL DEFAULT ltr,
+  `td_id` INTEGER NOT NULL,
+  UNIQUE (`td_id`)
+);
+
+-- ---
+-- Table 'question'
+--
+-- ---
+
+DROP TABLE IF EXISTS `question`;
+CREATE TABLE `question` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `text` TEXT NOT NULL,
+  `help` TEXT NOT NULL,
+  `is_required` INTEGER NOT NULL DEFAULT 0,
+  `input_type` TEXT NOT NULL,
+  `sort` INTEGER NOT NULL DEFAULT 0,
+  `depends_on` INTEGER NOT NULL DEFAULT -1,
+  `td_id` INTEGER NOT NULL,
+  `questionnaire_id` INTEGER NOT NULL,
+  UNIQUE(`td_id`, `questionnaire_id`),
+  FOREIGN KEY (questionnaire_id) REFERENCES `questionnaire` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'questionnaire_data_field'
+--
+-- ---
+
+DROP TABLE IF EXISTS `questionnaire_data_field`;
+
+CREATE TABLE `questionnaire_data_field` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `field` TEXT NOT NULL,
+  `question_td_id` INTEGER NOT NULL,
+  `questionnaire_id` INTEGER NOT NULL,
+  UNIQUE(`field`, `questionnaire_id`),
+  FOREIGN KEY (questionnaire_id) REFERENCES `questionnaire` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'target_language'
+--
+-- ---
+
+DROP TABLE IF EXISTS `target_language`;
+
+CREATE TABLE `target_language` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `name` TEXT NOT NULL,
+  `anglicized_name` TEXT NULL DEFAULT NULL,
+  `direction` TEXT NOT NULL DEFAULT ltr,
+  `region` TEXT NOT NULL DEFAULT '',
+  `is_gateway_language` INTEGER NOT NULL DEFAULT 0,
+  UNIQUE(`slug`)
+);
+
+-- ---
+-- Table 'temp_target_language'
+--
+-- ---
+
+DROP TABLE IF EXISTS `temp_target_language`;
+
+CREATE TABLE `temp_target_language` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `name` TEXT NOT NULL,
+  `anglicized_name` TEXT NULL DEFAULT NULL,
+  `direction` TEXT NOT NULL DEFAULT ltr,
+  `region` TEXT NOT NULL DEFAULT '',
+  `is_gateway_language` INTEGER NOT NULL DEFAULT 0,
+  `approved_target_language_slug` TEXT NULL DEFAULT NULL,
+  UNIQUE(`slug`)
+);
+
+-- ---
+-- Table 'versification_name'
+--
+-- ---
+
+DROP TABLE IF EXISTS `versification_name`;
+
+CREATE TABLE `versification_name` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `source_language_id` INTEGER NOT NULL,
+  `versification_id` INTEGER NOT NULL,
+  `name` TEXT NOT NULL,
+  FOREIGN KEY (source_language_id) REFERENCES `source_language` (`id`),
+  FOREIGN KEY (versification_id) REFERENCES `versification` (`id`) ON DELETE CASCADE,
+  UNIQUE(`source_language_id`, `versification_id`)
+);
+
+-- ---
+-- Table 'versification'
+--
+-- ---
+
+DROP TABLE IF EXISTS `versification`;
+
+CREATE TABLE `versification` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  UNIQUE(`slug`)
+);
+
+-- ---
+-- Table 'chunk_marker'
+--
+-- ---
+
+DROP TABLE IF EXISTS `chunk_marker`;
+
+CREATE TABLE `chunk_marker` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `chapter` TEXT NOT NULL,
+  `verse` TEXT NOT NULL,
+  `project_slug` TEXT NOT NULL,
+  `versification_id` INTEGER NOT NULL,
+  UNIQUE (`versification_id`, `project_slug`, `chapter`, `verse`),
+  FOREIGN KEY (versification_id) REFERENCES `versification` (`id`) ON DELETE CASCADE
+);
+
+-- ---
+-- Table 'catalog'
+--
+-- ---
+
+DROP TABLE IF EXISTS `catalog`;
+
+CREATE TABLE `catalog` (
+  `id` INTEGER NOT NULL PRIMARY KEY AUTOINCREMENT,
+  `slug` TEXT NOT NULL,
+  `url` TEXT NOT NULL,
+  `modified_at` INTEGER NOT NULL,
+  UNIQUE(`slug`)
+);
+
+-- ---
+-- Indexes
+-- ---
+
+CREATE INDEX `project_slug` ON `project`(`slug`);
+CREATE INDEX `project_category_id` ON `project`(`category_id`);
+
+CREATE INDEX `category_slug` ON `category`(`slug`);
+CREATE INDEX `category_parent_id` ON `category`(`parent_id`);
+
+CREATE INDEX `questionnaire_language_slug` ON `questionnaire`(`language_slug`);
+CREATE INDEX `question_depends_on` ON `question`(`depends_on`);
+CREATE INDEX `questionnaire_data_field_field` ON `questionnaire_data_field`(`field`);
+
+CREATE INDEX `source_language_slug` ON `source_language`(`slug`);
+
+CREATE INDEX `resource_slug` ON `resource`(`slug`);
+CREATE INDEX `resource_translate_mode` ON `resource`(`translate_mode`);
+CREATE INDEX `resource_checking_level` ON `resource`(`checking_level`);
+
+CREATE INDEX `resource_format_mime_type` ON `resource_format`(`mime_type`);
+
+CREATE INDEX `target_language_slug` ON `target_language`(`slug`);
+CREATE INDEX `target_language_name` ON `target_language`(`name`);
+
+CREATE INDEX `temp_target_language_slug` ON `temp_target_language`(`slug`);
+CREATE INDEX `temp_target_language_name` ON `temp_target_language`(`name`);
+CREATE INDEX `temp_target_language_approved_target_language_slug` ON `temp_target_language`(`approved_target_language_slug`);
+
+CREATE INDEX `versification_slug` ON `versification`(`slug`);
+
+CREATE INDEX `catalog_slug` ON `catalog`(`slug`);

--- a/app/src/main/java/com/door43/translationstudio/tasks/UpdateAppTask.java
+++ b/app/src/main/java/com/door43/translationstudio/tasks/UpdateAppTask.java
@@ -114,6 +114,14 @@ public class UpdateAppTask extends ManagedTask {
         }
         updateTargetTranslations();
         updateBuildNumbers();
+
+        // initialize the language url (langnames) from preference
+        try {
+            String languageUrl = App.getPref(SettingsActivity.KEY_PREF_LANGUAGES_URL, App.getRes(R.string.pref_default_language_url));
+            App.getLibrary().updateLanguageUrl(languageUrl);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
     }
 
     /**

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -319,6 +319,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGUAGES_URL);
                 langNameUrl.setText(langNameUrls[index]);
                 langNameUrl.setSummary(langNameUrls[index]);
+                langNameUrl.getOnPreferenceChangeListener().onPreferenceChange(langNameUrl, langNameUrls[index]); // triggers the listener of language url
 
                 return true;
             }

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -319,7 +319,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGUAGES_URL);
                 langNameUrl.setText(langNameUrls[index]);
                 langNameUrl.setSummary(langNameUrls[index]);
-                langNameUrl.getOnPreferenceChangeListener().onPreferenceChange(langNameUrl, langNameUrls[index]); // triggers the listener of language url
+                langNameUrl.getOnPreferenceChangeListener().onPreferenceChange(langNameUrl, langNameUrls[index]); // triggers the listener of language url preference
 
                 return true;
             }

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -77,6 +77,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
     public static final String KEY_PREF_ALWAYS_SHARE = "always_share";
     public static final String KEY_PREF_MEDIA_SERVER = "media_server";
     public static final String KEY_PREF_READER_SERVER = "reader_server";
+    public static final String KEY_PREF_LANGNAMES_URL = "lang_names_url";
     public static final String KEY_PREF_CREATE_ACCOUNT_URL = "create_account_url";
     public static final String KEY_PREF_COLOR_THEME = "color_theme";
 //    public static final String KEY_PREF_EXPORT_FORMAT = "export_format";
@@ -259,6 +260,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
 //        bindPreferenceSummaryToValue(findPreference(KEY_PREF_EXPORT_FORMAT));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
+        bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGNAMES_URL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_LOGGING_LEVEL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_BACKUP_INTERVAL));
@@ -307,6 +309,11 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 EditTextPreference readerServer = (EditTextPreference) findPreference(KEY_PREF_READER_SERVER);
                 readerServer.setText(readerServers[index]);
                 readerServer.setSummary(readerServers[index]);
+
+                String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
+                EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGNAMES_URL);
+                langNameUrl.setText(langNameUrls[index]);
+                langNameUrl.setSummary(langNameUrls[index]);
 
                 String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
                 EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
@@ -637,6 +644,11 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                         readerServer.setText(readerServers[index]);
                         readerServer.setSummary(readerServers[index]);
 
+                        String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
+                        EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGNAMES_URL);
+                        langNameUrl.setText(langNameUrls[index]);
+                        langNameUrl.setSummary(langNameUrls[index]);
+
                         String[] createAccountUrls = resources.getStringArray(R.array.content_server_account_create_urls_array);
                         EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
                         createAccountUrl.setText(createAccountUrls[index]);
@@ -656,6 +668,7 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_GIT_SERVER_PORT));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
+            bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGNAMES_URL));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
 
             initSettings = false;

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -354,23 +354,6 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             }
         });
 
-        final Preference languageUrl = findPreference(KEY_PREF_LANGUAGES_URL);
-        languageUrl.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
-            @Override
-            public boolean onPreferenceChange(Preference preference, Object value) {
-                String newValue = (String) value;
-
-                try {
-                    App.getLibrary().updateLanguageUrl(newValue);
-                } catch (Exception e) {
-                    e.printStackTrace();
-                    return false;
-                }
-
-                return true;
-            }
-        });
-
         initSettings = false;
     }
 
@@ -437,6 +420,15 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             } else if(preference.getKey().equals(KEY_PREF_LOGGING_LEVEL)) {
                 // TODO: only re-configure if changed
                 App.configureLogger(Integer.parseInt((String)value));
+            }
+
+            if (preference.getKey().equals(KEY_PREF_LANGUAGES_URL)) {
+                try {
+                    App.getLibrary().updateLanguageUrl(stringValue);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
             }
 
             if (preference instanceof ListPreference) {

--- a/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/SettingsActivity.java
@@ -77,8 +77,8 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
     public static final String KEY_PREF_ALWAYS_SHARE = "always_share";
     public static final String KEY_PREF_MEDIA_SERVER = "media_server";
     public static final String KEY_PREF_READER_SERVER = "reader_server";
-    public static final String KEY_PREF_LANGNAMES_URL = "lang_names_url";
     public static final String KEY_PREF_CREATE_ACCOUNT_URL = "create_account_url";
+    public static final String KEY_PREF_LANGUAGES_URL = "lang_names_url";
     public static final String KEY_PREF_COLOR_THEME = "color_theme";
 //    public static final String KEY_PREF_EXPORT_FORMAT = "export_format";
     public static final String KEY_PREF_TRANSLATION_TYPEFACE = "translation_typeface";
@@ -260,8 +260,8 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
 //        bindPreferenceSummaryToValue(findPreference(KEY_PREF_EXPORT_FORMAT));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
-        bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGNAMES_URL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
+        bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGUAGES_URL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_LOGGING_LEVEL));
         bindPreferenceSummaryToValue(findPreference(KEY_PREF_BACKUP_INTERVAL));
 
@@ -310,15 +310,15 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 readerServer.setText(readerServers[index]);
                 readerServer.setSummary(readerServers[index]);
 
-                String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
-                EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGNAMES_URL);
-                langNameUrl.setText(langNameUrls[index]);
-                langNameUrl.setSummary(langNameUrls[index]);
-
                 String[] createAccountUrls = getResources().getStringArray(R.array.content_server_account_create_urls_array);
                 EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
                 createAccountUrl.setText(createAccountUrls[index]);
                 createAccountUrl.setSummary(createAccountUrls[index]);
+
+                String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
+                EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGUAGES_URL);
+                langNameUrl.setText(langNameUrls[index]);
+                langNameUrl.setSummary(langNameUrls[index]);
 
                 return true;
             }
@@ -349,6 +349,23 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                 App.updateColorTheme(newValue);
                 mDelegate.applyDayNight();
                 recreate();
+
+                return true;
+            }
+        });
+
+        final Preference languageUrl = findPreference(KEY_PREF_LANGUAGES_URL);
+        languageUrl.setOnPreferenceChangeListener(new Preference.OnPreferenceChangeListener() {
+            @Override
+            public boolean onPreferenceChange(Preference preference, Object value) {
+                String newValue = (String) value;
+
+                try {
+                    App.getLibrary().updateLanguageUrl(newValue);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
 
                 return true;
             }
@@ -644,15 +661,15 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
                         readerServer.setText(readerServers[index]);
                         readerServer.setSummary(readerServers[index]);
 
-                        String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
-                        EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGNAMES_URL);
-                        langNameUrl.setText(langNameUrls[index]);
-                        langNameUrl.setSummary(langNameUrls[index]);
-
                         String[] createAccountUrls = resources.getStringArray(R.array.content_server_account_create_urls_array);
                         EditTextPreference createAccountUrl = (EditTextPreference) findPreference(KEY_PREF_CREATE_ACCOUNT_URL);
                         createAccountUrl.setText(createAccountUrls[index]);
                         createAccountUrl.setSummary(createAccountUrls[index]);
+
+                        String[] langNameUrls = getResources().getStringArray(R.array.content_server_lang_names_url_array);
+                        EditTextPreference langNameUrl = (EditTextPreference) findPreference(KEY_PREF_LANGUAGES_URL);
+                        langNameUrl.setText(langNameUrls[index]);
+                        langNameUrl.setSummary(langNameUrls[index]);
                     }
                 }
             });
@@ -668,8 +685,8 @@ public class SettingsActivity extends PreferenceActivity implements ManagedTask.
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_GIT_SERVER_PORT));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_MEDIA_SERVER));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_READER_SERVER));
-            bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGNAMES_URL));
             bindPreferenceSummaryToValue(findPreference(KEY_PREF_CREATE_ACCOUNT_URL));
+            bindPreferenceSummaryToValue(findPreference(KEY_PREF_LANGUAGES_URL));
 
             initSettings = false;
         }

--- a/app/src/main/java/com/door43/translationstudio/ui/newtranslation/NewTargetTranslationActivity.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/newtranslation/NewTargetTranslationActivity.java
@@ -362,11 +362,6 @@ public class NewTargetTranslationActivity extends BaseActivity implements Target
         } else {
             menu.findItem(R.id.action_update).setVisible(false);
         }
-        if(mFragment instanceof TargetLanguageListFragment) {
-            menu.findItem(R.id.action_add_language).setVisible(true);
-        } else {
-            menu.findItem(R.id.action_add_language).setVisible(false);
-        }
         SearchManager searchManager = (SearchManager)getSystemService(Context.SEARCH_SERVICE);
         final MenuItem searchMenuItem = menu.findItem(R.id.action_search);
         final SearchView searchViewAction = (SearchView) MenuItemCompat.getActionView(searchMenuItem);

--- a/app/src/main/java/org/unfoldingword/door43client/API.java
+++ b/app/src/main/java/org/unfoldingword/door43client/API.java
@@ -186,7 +186,7 @@ class API {
     }
 
     public void updateLanguageUrl(String url) {
-        LegacyTools.LANG_NAMES_URL = url;
+        LegacyTools.setLangNamesUrl(url);
     }
 
     /**

--- a/app/src/main/java/org/unfoldingword/door43client/API.java
+++ b/app/src/main/java/org/unfoldingword/door43client/API.java
@@ -185,6 +185,10 @@ class API {
         updateCatalog(c, null);
     }
 
+    public void updateLanguageUrl(String url) {
+        LegacyTools.LANG_NAMES_URL = url;
+    }
+
     /**
      * Downloads a global catalog and indexes it.
      *

--- a/app/src/main/java/org/unfoldingword/door43client/API.java
+++ b/app/src/main/java/org/unfoldingword/door43client/API.java
@@ -1,0 +1,710 @@
+package org.unfoldingword.door43client;
+
+import android.content.Context;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unfoldingword.door43client.models.Catalog;
+import org.unfoldingword.door43client.models.Category;
+import org.unfoldingword.door43client.models.Question;
+import org.unfoldingword.door43client.models.Questionnaire;
+import org.unfoldingword.door43client.models.SourceLanguage;
+import org.unfoldingword.door43client.models.TargetLanguage;
+import org.unfoldingword.resourcecontainer.ContainerTools;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+import org.unfoldingword.resourcecontainer.errors.InvalidRCException;
+import org.unfoldingword.resourcecontainer.errors.MissingRCException;
+import org.unfoldingword.resourcecontainer.errors.RCException;
+import org.unfoldingword.tools.http.GetRequest;
+
+import java.io.File;
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by joel on 8/30/16.
+ */
+class API {
+    public static final String LEGACY_WORDS_ASSIGNMENTS_URL = "words_assignments_url";
+    private static final OnLogListener defaultLogListener;
+    private static SQLiteHelper sqLiteHelper = null;
+
+    static {
+        defaultLogListener = new OnLogListener() {
+            @Override
+            public void onInfo(String message) {
+            }
+
+            @Override
+            public void onWarning(String message) {
+            }
+
+            @Override
+            public void onError(String message, Exception ex) {
+            }
+        };
+    }
+
+    private final File resourceDir;
+    private final Library library;
+    private String globalCatalogHost = null;
+    private OnLogListener logListener = defaultLogListener;
+
+    /**
+     * Initializes the new api client
+     * @param context the application context
+     * @param schema the database schema for the index
+     * @param databasePath the name of the database where information will be indexed
+     * @param resourceDir the directory where resource containers will be stored
+     */
+    public API(Context context, String schema, File databasePath, File resourceDir) throws IOException {
+        this.resourceDir = resourceDir;
+        String[] nameParts = databasePath.getName().split("\\.");
+        String dbExt = nameParts[nameParts.length - 1];
+        DatabaseContext databaseContext = new DatabaseContext(context, databasePath.getParentFile(), dbExt);
+        String dbName = databasePath.getName().replaceFirst("\\.[^\\.]+$", "");
+        synchronized (this) {
+            if (this.sqLiteHelper == null) {
+                sqLiteHelper = new SQLiteHelper(databaseContext, schema, dbName);
+            }
+        }
+        this.library = new Library(sqLiteHelper);
+    }
+
+    /**
+     * Performs closing operations.
+     * e.g. closing the db, etc.
+     */
+    public void tearDown() {
+        if(this.sqLiteHelper != null) {
+            this.sqLiteHelper.close();
+            this.sqLiteHelper = null;
+        }
+    }
+
+    /**
+     * Attaches a listener to receive log events
+     * @param listener
+     */
+    public void setLogger(OnLogListener listener) {
+        if(listener == null) {
+            this.logListener = defaultLogListener;
+        } else {
+            this.logListener = listener;
+        }
+    }
+
+    /**
+     * Sets the host to use when injecting the global catalogs.
+     * This is only valid until we migrate to the use api.
+     *
+     * This is also only currently used for tests
+     * @param host
+     */
+    @Deprecated
+    public void setGlobalCatalogServer(String host) {
+        this.globalCatalogHost = host;
+    }
+
+    /**
+     * Returns the read only index
+     * @return
+     */
+    public Index index() {
+        return library;
+    }
+
+    /**
+     * Indexes the source content
+     *
+     * @param url the entry resource api catalog
+     * @param listener an optional progress listener. This should receive progress id, total, completed
+     */
+    public void updateSources(String url, final OnProgressListener listener) throws Exception {
+        library.beginTransaction();
+        try {
+            GetRequest getPrimaryCatalog = new GetRequest(new URL(url));
+            String data = getPrimaryCatalog.read();
+            if(getPrimaryCatalog.getResponseCode() != 200) throw new Exception(getPrimaryCatalog.getResponseMessage());
+            // process legacy catalog data
+            LegacyTools.processCatalog(library, data, listener);
+        } catch(Exception e) {
+            library.endTransaction(false);
+            throw e;
+        }
+        library.endTransaction(true);
+    }
+
+    /**
+     * Indexes the chunk markers
+     * @param listener
+     * @throws Exception
+     */
+    public void updateChunks(OnProgressListener listener) throws Exception {
+        library.beginTransaction();
+        try {
+            LegacyTools.processChunks(library, listener);
+        } catch (Exception e) {
+            library.endTransaction(false);
+            throw e;
+        }
+        library.endTransaction(true);
+    }
+
+    /**
+     * Updates all the global catalogs
+     * @param listener
+     * @throws Exception
+     */
+    public void updateCatalogs(OnProgressListener listener) throws Exception {
+        // inject missing global catalogs
+        LegacyTools.injectGlobalCatalogs(library, globalCatalogHost);
+        List<Catalog> catalogs = library.getCatalogs();
+        for(Catalog c:catalogs) {
+            updateCatalog(c, listener);
+        }
+    }
+
+    /**
+     * Utility for testing
+     *
+     * @param slug
+     * @throws Exception
+     */
+    public void updateCatalog(String slug) throws Exception{
+        LegacyTools.injectGlobalCatalogs(library, globalCatalogHost);
+        Catalog c = library.getCatalog(slug);
+        updateCatalog(c, null);
+    }
+
+    /**
+     * Downloads a global catalog and indexes it.
+     *
+     * @param catalog the catalog being updated
+     * @param listener an optional progress listener. This should receive progress id, total, completed
+     */
+    private void updateCatalog(Catalog catalog, OnProgressListener listener) throws Exception {
+        if(catalog == null) throw new Exception("Unknown catalog");
+        GetRequest request = new GetRequest(new URL(catalog.url));
+        String data = request.read();
+        if(request.getResponseCode() != 200) throw new Exception(request.getResponseMessage());
+        library.beginTransaction();
+        try {
+            switch (catalog.slug) {
+                case "langnames":
+                    library.clearTargetLanguages();
+                    indexTargetLanguageCatalog(data, listener);
+                    break;
+                case "new-language-questions":
+                    library.clearNewLanguageQuestions();
+                    indexNewLanguageQuestionsCatalog(data, listener);
+                    break;
+                case "temp-langnames":
+                    library.clearTempLanguages();
+                    indexTempLanguagesCatalog(data, listener);
+                    break;
+                case "approved-temp-langnames":
+                    library.clearApprovedTempLanguages();
+                    indexApprovedTempLanguagesCatalog(data, listener);
+                    break;
+                default:
+                    throw new Exception("Parsing this catalog has not been implemented");
+            }
+        } catch (Exception e) {
+            library.endTransaction(false);
+            throw e;
+        }
+        library.endTransaction(true);
+    }
+
+    /**
+     * parses the target language catalog and indexes it
+     * @param data
+     * @param listener
+     */
+    private void indexTargetLanguageCatalog(String data, OnProgressListener listener) throws Exception {
+        JSONArray languages = new JSONArray(data);
+        for(int i = 0; i < languages.length(); i ++) {
+            JSONObject l = languages.getJSONObject(i);
+            boolean isGateway = l.has("gl") ? l.getBoolean("gl") : false;
+            TargetLanguage language = new TargetLanguage(l.getString("lc"), l.getString("ln"),
+                    l.getString("ang"), l.getString("ld"), l.getString("lr"), isGateway);
+            if(!library.addTargetLanguage(language)) {
+                logListener.onWarning("Failed to add the target language: " + language.slug);
+            }
+            if(listener != null) {
+                if(!listener.onProgress("langnames", languages.length(), i + 1)) break;
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Parses the new language questions catalog and indexes it
+     * @param data
+     * @param listener
+     */
+    private void indexNewLanguageQuestionsCatalog(String data, OnProgressListener listener) throws Exception {
+        JSONObject obj = new JSONObject(data);
+        JSONArray languages = obj.getJSONArray("languages");
+        for(int i = 0; i < languages.length(); i ++) {
+            JSONObject qJson = languages.getJSONObject(i);
+            Map<String, Long> dataFields = new HashMap<>();
+            if(qJson.has("language_data")) {
+                JSONObject dataFieldJson = qJson.getJSONObject("language_data");
+                Iterator<String> keyIter = dataFieldJson.keys();
+                while (keyIter.hasNext()) {
+                    String key = keyIter.next();
+                    dataFields.put(key, dataFieldJson.getLong(key));
+                }
+            }
+            Questionnaire questionnaire = new Questionnaire(qJson.getString("slug"),
+                    qJson.getString("name"),
+                    qJson.getString("dir"),
+                    qJson.getLong("questionnaire_id"),
+                    dataFields);
+            long questionnaireId = library.addQuestionnaire(questionnaire);
+
+            // add questions
+            for(int j = 0; j < qJson.getJSONArray("questions").length(); j ++) {
+                JSONObject questionJson = qJson.getJSONArray("questions").getJSONObject(j);
+                long dependsOnId = questionJson.isNull("depends_on") ? -1 : questionJson.getLong("depends_on");
+                Question question = new Question(questionJson.getString("text"),
+                        questionJson.getString("help"),
+                        questionJson.getBoolean("required"),
+                        Question.InputType.get(questionJson.getString("input_type")),
+                        questionJson.getInt("sort"),
+                        dependsOnId, questionJson.getLong("id"));
+                library.addQuestion(question, questionnaireId);
+
+                // broadcast itemized progress if there is only one questionnaire
+                if(languages.length() == 1 && listener != null) {
+                    if(!listener.onProgress("new-language-questions", qJson.getJSONArray("questions").length(), j + 1)) break;
+                }
+                library.yieldSafely();
+            }
+            // broadcast overall progress if there are multiple questionnaires.
+            if(languages.length() > 1 && listener != null) {
+                if(!listener.onProgress("new-language-questions", qJson.getJSONArray("questions").length(), i + 1)) break;
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Parses the temporary language codes catalog and indexes it
+     * @param data
+     * @param listener
+     */
+    private void indexTempLanguagesCatalog(String data, OnProgressListener listener) throws Exception {
+        JSONArray languages = new JSONArray(data);
+        for(int i = 0; i < languages.length(); i ++) {
+            JSONObject l = languages.getJSONObject(i);
+            boolean isGateway = l.has("gl") ? l.getBoolean("gl") : false;
+            TargetLanguage language = new TargetLanguage(l.getString("lc"), l.getString("ln"),
+                    l.getString("ang"), l.getString("ld"), l.getString("lr"), isGateway);
+            if(!library.addTempTargetLanguage(language)) {
+                logListener.onWarning("Failed to add the temp target language: " + language.slug);
+            }
+            if(listener != null) {
+                if(!listener.onProgress("temp-langnames", languages.length(), i + 1)) break;
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Parses the approved temporary language codes catalog and indexes it
+     * @param data
+     * @param listener
+     */
+    private void indexApprovedTempLanguagesCatalog(String data, OnProgressListener listener) throws Exception {
+        JSONArray languages = new JSONArray(data);
+        for(int i = 0; i < languages.length(); i ++) {
+            JSONObject l = languages.getJSONObject(i);
+            Iterator<String> keys = l.keys();
+            while(keys.hasNext()) {
+                String key = keys.next();
+                if(!library.setApprovedTargetLanguage(key, l.getString(key))) {
+                    logListener.onWarning("Failed to approve the temp target language: " + key + " as " + l.getString(key));
+                }
+            }
+            if(listener != null) {
+                if(!listener.onProgress("approved-temp-langnames", languages.length(), i + 1)) break;
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Downloads a resource container.
+     *
+     * TRICKY: to keep the interface stable we've abstracted some things.
+     * once the api supports real resource containers this entire method can go away and be replace
+     * with downloadContainer_Future (which should be renamed to downloadContainer).
+     * convertLegacyResourceToContainer will also become deprecated at that time though it may be handy to keep around.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return The new resource container
+     */
+    public ResourceContainer downloadResourceContainer(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        File path = downloadFutureCompatibleResourceContainer(sourceLanguageSlug, projectSlug, resourceSlug);
+
+        // migrate to resource container
+        Resource r = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(r == null) {
+            FileUtil.deleteQuietly(path);
+            throw new Exception("Unknown resource");
+        }
+        String data = FileUtil.readFileToString(path);
+
+        // clean downloaded file
+        FileUtil.deleteQuietly(path);
+        return convertLegacyResource(sourceLanguageSlug, projectSlug, resourceSlug, data);
+    }
+
+    /**
+     * Downloads a resource container.
+     * This expects a correctly formatted resource container
+     * and will download it directly to the disk
+     *
+     * once the api can deliver proper resource containers this method
+     * should be renamed to downloadContainer and the current downloadResourceContainer method removed.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return the path to the downloaded resource container
+     */
+    public File downloadFutureCompatibleResourceContainer(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        Resource r = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(r == null) throw new Exception("Unknown resource");
+        Resource.Format containerFormat = getResourceContainerFormat(r.formats);
+        if(containerFormat == null) throw new Exception("Missing resource container format");
+        String containerSlug = ContainerTools.makeSlug(sourceLanguageSlug, projectSlug, resourceSlug);
+        File containerDir = new File(resourceDir, containerSlug);
+        File destFile = new File(resourceDir, containerSlug + "." + ResourceContainer.fileExtension);
+
+        FileUtil.deleteQuietly(destFile);
+        FileUtil.deleteQuietly(containerDir);
+
+        destFile.getParentFile().mkdirs();
+        if(containerFormat.url == null || containerFormat.url.isEmpty()) throw new Exception("Missing resource format url");
+        GetRequest request = new GetRequest(new URL(containerFormat.url));
+        try {
+            request.download(destFile);
+        } catch(Exception e) {
+            FileUtil.deleteQuietly(destFile);
+            throw e;
+        }
+        if(request.getResponseCode() != 200) {
+            FileUtil.deleteQuietly(destFile);
+            throw new Exception(request.getResponseMessage());
+        }
+
+        return destFile;
+    }
+
+    /**
+     * Returns the first resource container format found in the list.
+     * E.g. the array may contain binary formats such as pdf, mp3, etc. This basically filters those.
+     *
+     * @param formats a list of resource formats
+     * @return
+     */
+    private static Resource.Format getResourceContainerFormat(List<Resource.Format> formats) {
+        for(Resource.Format f:formats) {
+            if(f.mimeType.matches(ResourceContainer.baseMimeType + "\\+.+")) {
+                return f;
+            }
+        }
+        return null;
+    }
+
+    /**
+     * Converts a legacy resource catalog into a resource container.
+     * The container will be placed in.
+     *
+     * This will be deprecated once the api is updated to support proper resource containers.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @param data the legacy data that will be converted
+     * @return
+     */
+    @Deprecated
+    public ResourceContainer convertLegacyResource(String sourceLanguageSlug, String projectSlug, String resourceSlug, String data) throws Exception {
+        String containerSlug = ContainerTools.makeSlug(sourceLanguageSlug, projectSlug, resourceSlug);
+        File containerDir = new File(resourceDir, containerSlug);
+
+        SourceLanguage language = library.getSourceLanguage(sourceLanguageSlug);
+        if(language == null) throw new Exception("Missing language");
+        JSONObject lJson = language.toJSON();
+
+        Project project = library.getProject(sourceLanguageSlug, projectSlug);
+        if(project == null) throw new Exception("Missing project");
+        JSONObject pJson = project.toJSON();
+        JSONArray pCatJson = new JSONArray();
+        List<Category> categories = library.getCategories(sourceLanguageSlug, projectSlug);
+        for(Category cat:categories) {
+            pCatJson.put(cat.slug);
+        }
+        pJson.put("categories", pCatJson);
+
+        Resource resource = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(resource == null) throw new Exception("Missing resource");
+        Resource.Format format = getResourceContainerFormat(resource.formats);
+        if(format == null) throw new Exception("Missing resource container format");
+        JSONObject rJson = resource.toJSON();
+
+        JSONObject properties = new JSONObject();
+        properties.put("language", lJson);
+        properties.put("project", pJson);
+        properties.put("resource", rJson);
+        properties.put("modified_at", format.modifiedAt);
+
+        // grab the tW assignments
+        if(resource._legacyData.containsKey(LEGACY_WORDS_ASSIGNMENTS_URL)
+                && resource._legacyData.get(LEGACY_WORDS_ASSIGNMENTS_URL) != null
+                && !resource._legacyData.get(LEGACY_WORDS_ASSIGNMENTS_URL).equals("")) {
+            GetRequest request = new GetRequest(new URL((String)resource._legacyData.get(LEGACY_WORDS_ASSIGNMENTS_URL)));
+            String wordsData = null;
+            try {
+                wordsData = request.read();
+            } catch (Exception e) {
+                e.printStackTrace();
+            }
+            if(wordsData != null && request.getResponseCode() < 300) {
+                try {
+                    JSONObject words = new JSONObject(wordsData);
+                    JSONObject assignmentsJson = new JSONObject();
+                    for(int c = 0; c < words.getJSONArray("chapters").length(); c ++) {
+                        JSONObject chapter = words.getJSONArray("chapters").getJSONObject(c);
+                        JSONObject chapterAssignment = new JSONObject();
+                        for(int f = 0; f < chapter.getJSONArray("frames").length(); f ++) {
+                            JSONObject frame = chapter.getJSONArray("frames").getJSONObject(f);
+                            JSONArray frameAssignment = new JSONArray();
+                            for(int w = 0; w < frame.getJSONArray("items").length(); w ++) {
+                                JSONObject word = frame.getJSONArray("items").getJSONObject(w);
+                                String twProjSlug = projectSlug.equals("obs") ? "bible-obs" : "bible";
+                                frameAssignment.put("//" + twProjSlug + "/tw/" + word.getString("id"));
+                            }
+                            chapterAssignment.put(LegacyTools.normalizeSlug(frame.getString("id")), frameAssignment);
+                        }
+                        assignmentsJson.put(LegacyTools.normalizeSlug(chapter.getString("id")), chapterAssignment);
+                    }
+                    properties.put("tw_assignments", assignmentsJson);
+                } catch (Exception e) {
+                    logListener.onWarning(e.getMessage());
+                }
+            }
+        }
+
+        return ContainerTools.convertResource(data, containerDir, properties);
+    }
+
+    /**
+     * Copies a valid resource container into the resource directory and adds an entry to the index.
+     * If the container already exists in the system it will be overwritten.
+     * Invalid containers will cause this method to return an error.
+     * The container *must* be open (uncompressed). This is in preparation for v0.2 of the rc spec.
+     * Containers imported in this manner will have a flag set to indicate it was manually imported.
+     *
+     * @param directory the path to the resource container directory that will be imported
+     * @return the imported resource container
+     */
+    public ResourceContainer importResourceContainer(File directory) throws Exception {
+        ResourceContainer rc = ResourceContainer.load(directory);
+        File destination = new File(resourceDir, rc.slug);
+
+        // validate project
+        // TRICKY: we currently only support importing known projects. Only the language and resource can vary.
+        JSONObject meta = library.getProjectMeta(rc.project.slug);
+        if(meta == null) throw new InvalidRCException("Unsupported project");
+
+        if(!rc.info.has("project")) throw new InvalidRCException("Missing field: project");
+
+        // delete the old container
+        deleteResourceContainer(rc.slug);
+
+        // copy new container
+        FileUtil.copyDirectory(directory, destination, null);
+
+        // add entry to the index
+        Exception indexError = null;
+        library.beginTransaction();
+        try {
+            long languageId = library.addSourceLanguage(new SourceLanguage(rc.language));
+
+            // build categories
+            List<Category> categories = new ArrayList<>();
+            try {
+                if(rc.info.has("project") && rc.info.getJSONObject("project").has("categories")) {
+                    JSONArray catJson = rc.info.getJSONObject("project").getJSONArray("categories");
+                    for (int i = 0; i < catJson.length(); i++) {
+                        String catSlug = catJson.getString(i);
+                        // use known name if available
+                        Category existingCat = library.getCategory(rc.language.slug, catSlug);
+                        String catName = existingCat == null ? catSlug : existingCat.name;
+                        categories.add(new Category(catSlug, catName));
+                    }
+                }
+            } catch (JSONException e) {
+                e.printStackTrace();
+            }
+
+            long projectId = library.addProject(rc.project, categories, languageId);
+            Resource resource = rc.resource;
+            resource.addFormat(new Resource.Format(rc.info.getString("package_version"), resource.type, rc.modifiedAt, "", true));
+            library.addResource(resource, projectId);
+        } catch (Exception e) {
+            indexError = e;
+        }
+        library.endTransaction(indexError == null);
+        if(indexError != null) throw indexError;
+
+        return openResourceContainer(rc.language.slug, rc.project.slug, rc.resource.slug);
+    }
+
+    /**
+     * Exports the closed resource container
+     * @param destFile the destination file
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     */
+    public void exportResourceContainer(File destFile, String languageSlug, String projectSlug, String resourceSlug) throws Exception {
+        String slug = ContainerTools.makeSlug(languageSlug, projectSlug, resourceSlug);
+        File srcDir = new File(resourceDir, slug);
+        File srcFile = new File(srcDir + "." + ResourceContainer.fileExtension);
+
+        // create closed rc
+        if(!srcFile.exists() && srcDir.isDirectory()) ResourceContainer.close(srcDir);
+        if(!srcFile.exists()) throw new MissingRCException("The resource container could not be found at " + srcFile);
+
+        FileUtil.copyFile(srcFile, destFile);
+    }
+
+    /**
+     * Opens a resource container archive so it's contents can be read.
+     * The index will be referenced to validate the resource and retrieve the container type.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     */
+    public ResourceContainer openResourceContainer(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        Resource resource = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(resource == null) {
+            throw new Exception("Unknown Resource");
+        }
+        String containerSlug = ContainerTools.makeSlug(sourceLanguageSlug, projectSlug, resourceSlug);
+        return openResourceContainer(containerSlug);
+    }
+
+    /**
+     * Opens a resource container archive so it's contents can be read.
+     * This will NOT check with the index to validate the resource container.
+     * @param containerSlug
+     * @return
+     * @throws Exception
+     */
+    public ResourceContainer openResourceContainer(String containerSlug) throws Exception {
+        File directory = new File(resourceDir, containerSlug);
+        File archive = new File(directory + "." + ResourceContainer.fileExtension);
+
+        // try to load already opened container first
+        try {
+            if(directory.exists() && directory.isDirectory()) {
+                return ResourceContainer.load(directory);
+            }
+        } catch (Exception e) {}
+
+        // open archive as last resource
+        return ResourceContainer.open(archive, directory);
+    }
+
+    /**
+     * Closes a resource container archive.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return the path to the closed container
+     */
+    public File closeResourceContainer(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        Resource resource = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(resource == null) {
+            throw new Exception("Unknown Resource");
+        }
+        String containerSlug = ContainerTools.makeSlug(sourceLanguageSlug, projectSlug, resourceSlug);
+        File directory = new File(resourceDir, containerSlug);
+        return ResourceContainer.close(directory);
+    }
+
+    /**
+     * Checks when a resource container was last modified.
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     */
+    public int getResourceContainerLastModified(String sourceLanguageSlug, String projectSlug, String resourceSlug) {
+        Resource resource = library.getResource(sourceLanguageSlug, projectSlug, resourceSlug);
+        if(resource != null) {
+            Resource.Format format = getResourceContainerFormat(resource.formats);
+            if(format != null) return format.modifiedAt;
+        }
+        return -1;
+    }
+
+    /**
+     * Checks if the resource container has been downloaded
+     * @param containerSlug
+     * @return
+     */
+    public boolean resourceContainerExists(String containerSlug) {
+        File directory = new File(resourceDir, containerSlug);
+        File archive = new File(directory + "." + ResourceContainer.fileExtension);
+        return (directory.exists() && directory.isDirectory()) || (archive.exists() && archive.isFile());
+    }
+
+    /**
+     * Checks if the resource container has been downloaded
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     */
+    public boolean resourceContainerExists(String languageSlug, String projectSlug, String resourceSlug) {
+        String containerSlug = ContainerTools.makeSlug(languageSlug, projectSlug, resourceSlug);
+        return resourceContainerExists(containerSlug);
+    }
+
+    /**
+     * Deletes a resource container from the disk
+     * @param containerSlug
+     */
+    public void deleteResourceContainer(String containerSlug) {
+        File directory = new File(resourceDir, containerSlug);
+        File archive = new File(directory + "." + ResourceContainer.fileExtension);
+        if(directory.exists() && directory.isDirectory()) {
+            FileUtil.deleteQuietly(directory);
+        }
+        if(archive.exists() && archive.isFile()) {
+            FileUtil.deleteQuietly(archive);
+        }
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/DatabaseContext.java
+++ b/app/src/main/java/org/unfoldingword/door43client/DatabaseContext.java
@@ -1,0 +1,77 @@
+package org.unfoldingword.door43client;
+
+
+import android.content.Context;
+import android.content.ContextWrapper;
+import android.database.DatabaseErrorHandler;
+import android.database.sqlite.SQLiteDatabase;
+
+import java.io.File;
+
+/**
+ * Custom wrapper to provide a custom database path
+ * http://stackoverflow.com/questions/5332328/sqliteopenhelper-problem-with-fully-qualified-db-path-name
+ */
+class DatabaseContext extends ContextWrapper {
+
+    private final File dir;
+    private final String dbExt;
+
+    /**
+     *
+     * @param base
+     * @param databaseDir the directory where databases will be stored
+     * @param dbExt the file extension to use for databases
+     */
+    public DatabaseContext(Context base, File databaseDir, String dbExt) {
+        super(base);
+        this.dir = databaseDir;
+        if(dbExt == null || dbExt.isEmpty()) {
+            this.dbExt = "db";
+        } else {
+            this.dbExt = dbExt;
+        }
+    }
+
+    @Override
+    public File getDatabasePath(String name) {
+        String dbfile = dir.getAbsolutePath() + File.separator + name;
+
+        if (!dbfile.endsWith("." + dbExt)) {
+            dbfile += "." + dbExt;
+        }
+
+        File result = new File(dbfile);
+
+        if (!result.getParentFile().exists()) {
+            result.getParentFile().mkdirs();
+        }
+
+        return result;
+    }
+
+    /**
+     * for devices greater than or equal to  api v11
+     * @param name
+     * @param mode
+     * @param factory
+     * @param errorHandler
+     * @return
+     */
+    @Override
+    public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory, DatabaseErrorHandler errorHandler) {
+        return openOrCreateDatabase(name, mode, factory);
+    }
+
+    /**
+     * For devices less than api v11
+     * @param name
+     * @param mode
+     * @param factory
+     * @return
+     */
+    @Override
+    public SQLiteDatabase openOrCreateDatabase(String name, int mode, SQLiteDatabase.CursorFactory factory) {
+        return SQLiteDatabase.openOrCreateDatabase(getDatabasePath(name), null);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/Door43Client.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Door43Client.java
@@ -1,0 +1,222 @@
+package org.unfoldingword.door43client;
+
+import android.content.Context;
+
+import org.unfoldingword.resourcecontainer.ContainerTools;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+import org.unfoldingword.tools.http.Request;
+
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+
+/**
+ * Provides a interface to the Door43 resource api
+ */
+
+public class Door43Client {
+
+    private final API api;
+    private static String schema = null;
+    /**
+     * The (mostly) read only index
+     */
+    public final Index index;
+
+    /**
+     * Initializes a new Door43 client
+     * @param context the application context
+     * @param databasePath the name of the database where information will be indexed
+     * @param resourceDir the directory where resource containers will be stored
+     * @throws IOException
+     */
+    public Door43Client(Context context, File databasePath, File resourceDir) throws IOException {
+        // load schema
+        if(this.schema == null) {
+            InputStream is = context.getAssets().open("schema.sqlite");
+            BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+            StringBuilder sb = new StringBuilder();
+            String line;
+            while ((line = reader.readLine()) != null) {
+                sb.append(line).append("\n");
+            }
+            this.schema = sb.toString();
+        }
+
+        this.api = new API(context, this.schema, databasePath, resourceDir);
+        this.index = api.index();
+    }
+
+    /**
+     * Attaches a listener to receive log events
+     * @param listener
+     */
+    public void setLogger(OnLogListener listener) {
+        api.setLogger(listener);
+    }
+
+    /**
+     * Returns the read only index
+     * @return the index
+     */
+    @Deprecated
+    public Index index() {
+        return api.index();
+    }
+
+    /**
+     * Checks when an indexed (not downloaded) resource container was last modified.
+     * This looks at the modified date in the resource format.
+     * The result is the last known modification date of what's available in the api.
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     */
+    public int getResourceContainerLastModified(String sourceLanguageSlug, String projectSlug, String resourceSlug) {
+        return api.getResourceContainerLastModified(sourceLanguageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Indexes the source content
+     *
+     * @param url the entry resource api catalog
+     * @param listener an optional progress listener. This should receive progress id, total, completed
+     */
+    public void updateSources(String url, OnProgressListener listener) throws Exception {
+        api.updateSources(url, listener);
+    }
+
+    /**
+     * Indexes the supplementary catalogs
+     * @param listener
+     * @throws Exception
+     */
+    public void updateCatalogs(OnProgressListener listener) throws Exception {
+        api.updateCatalogs(listener);
+    }
+
+    /**
+     * Indexes the chunk markers
+     * @param listener
+     * @throws Exception
+     */
+    public void updateChunks(OnProgressListener listener) throws Exception {
+        api.updateChunks(listener);
+    }
+
+    /**
+     * Downloads a resource container from the api
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     * @throws Exception
+     */
+    public ResourceContainer download(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        return api.downloadResourceContainer(sourceLanguageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Opens a resource container archive so it's contents can be read.
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     * @throws Exception
+     */
+    public ResourceContainer open(String languageSlug, String projectSlug, String resourceSlug) throws Exception {
+        return api.openResourceContainer(languageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Opens a resource container archive so it's contents can be read.
+     * @param containerSlug
+     * @return
+     */
+    public ResourceContainer open(String containerSlug) throws Exception {
+        return api.openResourceContainer(containerSlug);
+    }
+
+    /**
+     * Imports an external resource container into the client and indexes it for use.
+     * @param directory the directory of the resource container to be imported
+     * @return the imported resource container
+     * @throws Exception
+     */
+    public ResourceContainer importResourceContainer(File directory) throws Exception {
+        return api.importResourceContainer(directory);
+    }
+
+    /**
+     * Exports the closed resource container
+     * @param destFile the destination file
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     */
+    public void exportResourceContainer(File destFile, String languageSlug, String projectSlug, String resourceSlug) throws Exception {
+        api.exportResourceContainer(destFile, languageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Checks if a resource container has been downloaded
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return
+     */
+    public boolean exists(String languageSlug, String projectSlug, String resourceSlug) {
+        return api.resourceContainerExists(languageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Checks if a resource container has been downloaded
+     * @param containerSlug
+     * @return
+     */
+    public boolean exists(String containerSlug) {
+        return api.resourceContainerExists(containerSlug);
+    }
+
+    /**
+     * Deletes a resource container
+     * @param languageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     */
+    public void delete(String languageSlug, String projectSlug, String resourceSlug) {
+        delete(ContainerTools.makeSlug(languageSlug, projectSlug, resourceSlug));
+    }
+
+    /**
+     * Deletes a resource container
+     * @param containerSlug
+     */
+    public void delete(String containerSlug) {
+        api.deleteResourceContainer(containerSlug);
+    }
+
+    /**
+     * Closes a resource container directory
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @throws Exception
+     */
+    public void close(String sourceLanguageSlug, String projectSlug, String resourceSlug) throws Exception {
+        api.closeResourceContainer(sourceLanguageSlug, projectSlug, resourceSlug);
+    }
+
+    /**
+     * Closes the api
+     */
+    public void tearDown() {
+        api.tearDown();
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/Door43Client.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Door43Client.java
@@ -101,6 +101,10 @@ public class Door43Client {
         api.updateCatalogs(listener);
     }
 
+    public void updateLanguageUrl(String url) throws Exception {
+        api.updateLanguageUrl(url);
+    }
+
     /**
      * Indexes the chunk markers
      * @param listener

--- a/app/src/main/java/org/unfoldingword/door43client/FileUtil.java
+++ b/app/src/main/java/org/unfoldingword/door43client/FileUtil.java
@@ -1,0 +1,382 @@
+package org.unfoldingword.door43client;
+
+import java.io.BufferedReader;
+import java.io.Closeable;
+import java.io.File;
+import java.io.FileFilter;
+import java.io.FileInputStream;
+import java.io.FileNotFoundException;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.InputStreamReader;
+import java.io.OutputStream;
+import java.nio.channels.FileChannel;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * Created by joel on 9/1/16.
+ */
+class FileUtil {
+
+    /**
+     * Converts an input stream into a string
+     * @param is
+     * @return
+     * @throws IOException
+     */
+    public static String readStreamToString(InputStream is) throws IOException {
+        BufferedReader reader = new BufferedReader(new InputStreamReader(is));
+        StringBuilder sb = new StringBuilder();
+        String line;
+        while ((line = reader.readLine()) != null) {
+            sb.append(line).append("\n");
+        }
+        return sb.toString();
+    }
+
+    /**
+     * Returns the contents of a file as a string
+     * @param file
+     * @return
+     * @throws IOException
+     */
+    public static String readFileToString(File file) throws IOException {
+        FileInputStream fis = null;
+        try {
+            fis = new FileInputStream(file);
+            String contents = readStreamToString(fis);
+            fis.close();
+            return contents;
+        } finally {
+            if(fis != null) {
+                fis.close();
+            }
+        }
+    }
+
+    /**
+     * Writes a string to a file
+     * @param file
+     * @param contents
+     * @throws IOException
+     */
+    public static void writeStringToFile(File file, String contents) throws IOException {
+        FileOutputStream fos = null;
+        try {
+            fos = new FileOutputStream(file.getAbsolutePath());
+            fos.write(contents.getBytes());
+        } finally {
+            if(fos != null) {
+                fos.close();
+            }
+        }
+    }
+
+    public static void copyInputStreamToFile(InputStream source, File destination) throws IOException {
+        try {
+            FileOutputStream output = openOutputStream(destination);
+
+            try {
+                copy(source, output);
+                output.close();
+            } finally {
+                closeQuietly(output);
+            }
+        } finally {
+            closeQuietly(source);
+        }
+
+    }
+
+    public static FileOutputStream openOutputStream(File file) throws IOException {
+        return openOutputStream(file, false);
+    }
+
+    public static FileOutputStream openOutputStream(File file, boolean append) throws IOException {
+        if(file.exists()) {
+            if(file.isDirectory()) {
+                throw new IOException("File \'" + file + "\' exists but is a directory");
+            }
+
+            if(!file.canWrite()) {
+                throw new IOException("File \'" + file + "\' cannot be written to");
+            }
+        } else {
+            File parent = file.getParentFile();
+            if(parent != null && !parent.mkdirs() && !parent.isDirectory()) {
+                throw new IOException("Directory \'" + parent + "\' could not be created");
+            }
+        }
+
+        return new FileOutputStream(file, append);
+    }
+
+    public static int copy(InputStream input, OutputStream output) throws IOException {
+        long count = copyLarge(input, output);
+        return count > 2147483647L?-1:(int)count;
+    }
+
+    /**
+     * Returns the extension of the file.
+     * If no delimiter is found or there is no extension the result is an empty string
+     * @param path
+     * @return
+     */
+    public static String getExtension(String path) {
+        int index = path.lastIndexOf(".");
+        if(index == -1 || index == path.length() - 1) {
+            return "";
+        }
+        return path.substring(index + 1);
+    }
+
+    public static long copyLarge(InputStream input, OutputStream output) throws IOException {
+        return copyLarge(input, output, new byte[4096]);
+    }
+
+    public static long copyLarge(InputStream input, OutputStream output, byte[] buffer) throws IOException {
+        long count = 0L;
+
+        int n1;
+        for(boolean n = false; -1 != (n1 = input.read(buffer)); count += (long)n1) {
+            output.write(buffer, 0, n1);
+        }
+
+        return count;
+    }
+
+    /**
+     * Recursively deletes a directory or just deletes the file
+     * @param fileOrDirectory
+     */
+    public static boolean deleteQuietly(File fileOrDirectory) {
+        if(fileOrDirectory != null) {
+            if (fileOrDirectory.isDirectory()) {
+                File[] files = fileOrDirectory.listFiles();
+                if(files != null) {
+                    for (File child : fileOrDirectory.listFiles()) {
+                        if (!deleteQuietly(child)) {
+                            return false;
+                        }
+                    }
+                }
+            }
+            if (fileOrDirectory.exists()) {
+                try {
+                    fileOrDirectory.delete();
+                } catch (Exception e) {
+                    e.printStackTrace();
+                    return false;
+                }
+            }
+        }
+        return true;
+    }
+
+    /**
+     * Attempts to move a file or directory. If moving fails it will try to copy instead.
+     * @param sourceFile
+     * @param destFile
+     * @return
+     */
+    public static boolean moveOrCopyQuietly(File sourceFile, File destFile) {
+        if(sourceFile.exists()) {
+            // first try to move
+            if (!sourceFile.renameTo(destFile)) {
+                // try to copy
+                try {
+                    if (sourceFile.isDirectory()) {
+                        copyDirectory(sourceFile, destFile, null);
+                    } else {
+                        copyFile(sourceFile, destFile);
+                    }
+                    return true;
+                } catch (IOException e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+        return false;
+    }
+
+    /**
+     * Deletes a file/directory by first moving it to a temporary location then deleting it.
+     * This avoids an issue with FAT32 on some devices where you cannot create a file
+     * with the same name right after deleting it
+     * @param file
+     */
+    public static void safeDelete(File file) {
+        if(file != null && file.exists()) {
+            File temp = new File(file.getParentFile(), System.currentTimeMillis() + ".trash");
+            file.renameTo(temp);
+            if (file.isDirectory()) {
+                moveOrCopyQuietly(file, new File(temp, file.getName()));
+            } else {
+                moveOrCopyQuietly(file, temp);
+            }
+            deleteQuietly(file); // just in case the move failed
+            deleteQuietly(temp);
+        }
+    }
+
+    public static void copyDirectory(File srcDir, File destDir, FileFilter filter) throws IOException {
+        if(srcDir == null) {
+            throw new NullPointerException("Source must not be null");
+        } else if(destDir == null) {
+            throw new NullPointerException("Destination must not be null");
+        } else if(!srcDir.exists()) {
+            throw new FileNotFoundException("Source \'" + srcDir + "\' does not exist");
+        } else if(!srcDir.isDirectory()) {
+            throw new IOException("Source \'" + srcDir + "\' exists but is not a directory");
+        } else if(srcDir.getCanonicalPath().equals(destDir.getCanonicalPath())) {
+            throw new IOException("Source \'" + srcDir + "\' and destination \'" + destDir + "\' are the same");
+        } else {
+            ArrayList exclusionList = null;
+            if(destDir.getCanonicalPath().startsWith(srcDir.getCanonicalPath())) {
+                File[] srcFiles = filter == null?srcDir.listFiles():srcDir.listFiles(filter);
+                if(srcFiles != null && srcFiles.length > 0) {
+                    exclusionList = new ArrayList(srcFiles.length);
+                    File[] arr$ = srcFiles;
+                    int len$ = srcFiles.length;
+
+                    for(int i$ = 0; i$ < len$; ++i$) {
+                        File srcFile = arr$[i$];
+                        File copiedFile = new File(destDir, srcFile.getName());
+                        exclusionList.add(copiedFile.getCanonicalPath());
+                    }
+                }
+            }
+
+            doCopyDirectory(srcDir, destDir, filter, exclusionList);
+        }
+    }
+
+    private static void doCopyDirectory(File srcDir, File destDir, FileFilter filter, List<String> exclusionList) throws IOException {
+        File[] srcFiles = filter == null?srcDir.listFiles():srcDir.listFiles(filter);
+        if(srcFiles == null) {
+            throw new IOException("Failed to list contents of " + srcDir);
+        } else {
+            if(destDir.exists()) {
+                if(!destDir.isDirectory()) {
+                    throw new IOException("Destination \'" + destDir + "\' exists but is not a directory");
+                }
+            } else if(!destDir.mkdirs() && !destDir.isDirectory()) {
+                throw new IOException("Destination \'" + destDir + "\' directory cannot be created");
+            }
+
+            if(!destDir.canWrite()) {
+                throw new IOException("Destination \'" + destDir + "\' cannot be written to");
+            } else {
+                File[] arr$ = srcFiles;
+                int len$ = srcFiles.length;
+
+                for(int i$ = 0; i$ < len$; ++i$) {
+                    File srcFile = arr$[i$];
+                    File dstFile = new File(destDir, srcFile.getName());
+                    if(exclusionList == null || !exclusionList.contains(srcFile.getCanonicalPath())) {
+                        if(srcFile.isDirectory()) {
+                            doCopyDirectory(srcFile, dstFile, filter, exclusionList);
+                        } else {
+                            doCopyFile(srcFile, dstFile);
+                        }
+                    }
+                }
+
+                // reserve date
+                destDir.setLastModified(srcDir.lastModified());
+            }
+        }
+    }
+
+    /**
+     * Copies a file or directory
+     * @param srcFile
+     * @param destFile
+     */
+    public static void copyFile(File srcFile, File destFile) throws IOException {
+        if(srcFile == null) {
+            throw new NullPointerException("Source must not be null");
+        } else if(destFile == null) {
+            throw new NullPointerException("Destination must not be null");
+        } else if(!srcFile.exists()) {
+            throw new FileNotFoundException("Source \'" + srcFile + "\' does not exist");
+        } else if(srcFile.isDirectory()) {
+            throw new IOException("Source \'" + srcFile + "\' exists but is a directory");
+        } else if(srcFile.getCanonicalPath().equals(destFile.getCanonicalPath())) {
+            throw new IOException("Source \'" + srcFile + "\' and destination \'" + destFile + "\' are the same");
+        } else {
+            File parentFile = destFile.getParentFile();
+            if(parentFile != null && !parentFile.mkdirs() && !parentFile.isDirectory()) {
+                throw new IOException("Destination \'" + parentFile + "\' directory cannot be created");
+            } else if(destFile.exists() && !destFile.canWrite()) {
+                throw new IOException("Destination \'" + destFile + "\' exists but is read-only");
+            } else {
+                doCopyFile(srcFile, destFile);
+            }
+        }
+    }
+
+    private static void doCopyFile(File srcFile, File destFile) throws IOException {
+        if(destFile.exists() && destFile.isDirectory()) {
+            throw new IOException("Destination \'" + destFile + "\' exists but is a directory");
+        } else {
+            FileInputStream fis = null;
+            FileOutputStream fos = null;
+            FileChannel input = null;
+            FileChannel output = null;
+
+            try {
+                fis = new FileInputStream(srcFile);
+                fos = new FileOutputStream(destFile);
+                input = fis.getChannel();
+                output = fos.getChannel();
+                long size = input.size();
+                long pos = 0L;
+
+                for(long count = 0L; pos < size; pos += output.transferFrom(input, pos, count)) {
+                    count = size - pos > 31457280L?31457280L:size - pos;
+                }
+            } finally {
+                closeQuietly(output);
+                closeQuietly(fos);
+                closeQuietly(input);
+                closeQuietly(fis);
+            }
+
+            if(srcFile.length() != destFile.length()) {
+                throw new IOException("Failed to copy full contents from \'" + srcFile + "\' to \'" + destFile + "\'");
+            } else {
+                // preserve date
+                destFile.setLastModified(srcFile.lastModified());
+            }
+        }
+    }
+
+    /**
+     * closes the closable without throwing an exception
+     * @param closable
+     */
+    public static void closeQuietly(Closeable closable) {
+        try {
+            closable.close();
+        } catch (IOException e) {
+            e.printStackTrace();
+        }
+    }
+
+    public static void forceMkdir(File directory) throws IOException {
+        String message;
+        if(directory.exists()) {
+            if(!directory.isDirectory()) {
+                message = "File " + directory + " exists and is " + "not a directory. Unable to create directory.";
+                throw new IOException(message);
+            }
+        } else if(!directory.mkdirs() && !directory.isDirectory()) {
+            message = "Unable to create directory " + directory;
+            throw new IOException(message);
+        }
+
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/Index.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Index.java
@@ -1,0 +1,293 @@
+package org.unfoldingword.door43client;
+
+import org.unfoldingword.door43client.models.Catalog;
+import org.unfoldingword.door43client.models.Category;
+import org.unfoldingword.door43client.models.CategoryEntry;
+import org.unfoldingword.door43client.models.ChunkMarker;
+import org.unfoldingword.door43client.models.Question;
+import org.unfoldingword.door43client.models.Questionnaire;
+import org.unfoldingword.door43client.models.SourceLanguage;
+import org.unfoldingword.door43client.models.TargetLanguage;
+import org.unfoldingword.door43client.models.Translation;
+import org.unfoldingword.door43client.models.Versification;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+
+import java.io.File;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Defines the public methods of the index
+ */
+public interface Index {
+
+    /**
+     * Inserts or updates a temporary target language in the library.
+     *
+     * Note: the result is boolean since you don't need the row id. See getTargetLanguages for more information
+     *
+     * @param language
+     * @return
+     * @throws Exception
+     */
+    boolean addTempTargetLanguage(TargetLanguage language) throws Exception;
+
+    /**
+     * Returns a list of source languages and when they were last modified.
+     * The value is taken from the max modified resource format date within the language
+     *
+     * @return {slug, modified_at}
+     */
+    List<HashMap> listSourceLanguagesLastModified();
+
+    /**
+     * Returns a list of projects and when they were last modified
+     * The value is taken from the max modified resource format date within the project
+     *
+     * @param languageSlug the source language who's projects will be selected. If left empty the results will include all projects in all languages.
+     * @return
+     */
+    Map<String, Integer> listProjectsLastModified(String languageSlug);
+
+    /**
+     * Returns a translation that matches the resource container slug
+     *
+     * @param containerSlug
+     * @return
+     */
+    Translation getTranslation(String containerSlug);
+
+    /**
+     * Returns a list of translations available for the project
+     *
+     * @param languageSlug the language these translations are available in. Leave null for all.
+     * @param projectSlug the project for whom these translations are available. Leave null for all
+     * @param resourceSlug the resource for whom these translations are available. Leave null for all
+     * @param resourceType the resource type allowed for returned translations. Leave null for all.
+     * @param translateMode limit the results to just those with the given translate mode. Leave null for all
+     * @param minCheckingLevel the minimum checking level allowed for returned translations. Use 0 for no minimum
+     * @param maxCheckingLevel the maximum checking level allowed for returned translations. Use -1 for no maximum
+     * @return a list of matching translations
+     */
+    List<Translation> findTranslations(String languageSlug, String projectSlug, String resourceSlug, String resourceType, String translateMode, int minCheckingLevel, int maxCheckingLevel);
+
+    /**
+     * Returns a list of translations that have been manually imported by the user.
+     *
+     * @return a list of translations
+     */
+    List<Translation> getImportedTranslations();
+
+    /**
+     * Returns a source language.
+     *
+     * @param sourceLanguageSlug
+     * @return the language object or null if it does not exist
+     */
+    SourceLanguage getSourceLanguage(String sourceLanguageSlug);
+
+    /**
+     * Returns a list of every source language.
+     *
+     * @return an array of source languages
+     */
+    List<SourceLanguage> getSourceLanguages();
+
+    /**
+     * Returns a list of source languages in which the project exists.
+     *
+     * @return an array of source languages
+     */
+    List<SourceLanguage> getSourceLanguages(String projectSlug);
+
+    /**
+     * Returns a target language.
+     * The result may be a temp target language.
+     *
+     * Note: does not include the row id. You don't need it
+     *
+     * @param targetLangaugeSlug
+     * @return the language object or null if it does not exist
+     */
+    TargetLanguage getTargetLanguage(String targetLangaugeSlug);
+
+    /**
+     * Searches for a target language by name.
+     * @param namequery
+     * @return
+     */
+    List<TargetLanguage> findTargetLanguage(final String namequery);
+
+    /**
+     * Returns a list of every target language.
+     * The result may include temp target languages.
+     *
+     * Note: does not include the row id. You don't need it.
+     * And we are pulling from two tables so it would be confusing.
+     *
+     * @return
+     */
+    List<TargetLanguage> getTargetLanguages();
+
+    /**
+     * Returns the target language that has been assigned to a temporary target language.
+     *
+     * Note: does not include the row id. You don't need it
+     *
+     * @param tempTargetLanguageSlug the temporary target language with the assignment
+     * @return the language object or null if it does not exist
+     */
+    TargetLanguage getApprovedTargetLanguage(String tempTargetLanguageSlug);
+
+    /**
+     * Returns a project with the option of falling back to a default language if not found
+     *
+     * @param sourceLanguageSlug the source language code for which the project will be returned
+     * @param projectSlug the project code
+     * @param enableDefaultLanguage allows this method to use the default language if no project is found in this language
+     * @return the project object or null
+     */
+    Project getProject(String sourceLanguageSlug, String projectSlug, boolean enableDefaultLanguage);
+
+    /**
+     * Returns a project
+     *
+     * @param sourceLanguageSlug the source language code for which the project will be returned
+     * @param projectSlug the project code
+     * @return the project object or null
+     */
+    Project getProject(String sourceLanguageSlug, String projectSlug);
+
+    /**
+     * Returns a list of projects available in the given language.
+     *
+     * @param sourceLanguageSlug the source language code for which projects will be returned
+     * @return an array of projects that are available in the source language
+     */
+    List<Project> getProjects(String sourceLanguageSlug);
+
+    /**
+     * Returns a list of projects in the given language or (if enabled) a default language.
+     * The affect is a list of all unique projects with preference given to the specified language
+     *
+     * @param sourceLanguageSlug the source language code for which projects will be returned
+     * @param enableDefaultLanguage if true the default language will be used to fetch the remaining projects
+     * @return an array of projects that are available in the source language
+     */
+    List<Project> getProjects(String sourceLanguageSlug, boolean enableDefaultLanguage);
+
+    /**
+     * Returns an array of categories that exist underneath the parent category.
+     * The results of this method are a combination of categories and projects.
+     *
+     * @param parentCategoryId the category who's children will be returned. If 0 then all top level categories will be returned.
+     * @param languageSlug the language in which the category titles will be displayed
+     * @param translateMode limit the results to just those with the given translate mode. Leave this falsy to not filter
+     * @return
+     */
+    List<CategoryEntry> getProjectCategories(long parentCategoryId, String languageSlug, String translateMode);
+
+    /**
+     * Returns a resource
+     *
+     * @param sourceLanguageSlug
+     * @param projectSlug
+     * @param resourceSlug
+     * @return the Resource object or null if it does not exist
+     */
+    Resource getResource(String sourceLanguageSlug, String projectSlug, String resourceSlug);
+
+    /**
+     * Returns a list of resources available in the given project
+     *
+     * @param sourcelanguageSlug the language of the resource. If null then all resources of the project will be returned.
+     * @param projectSlug the project who's resources will be returned
+     * @return
+     */
+    List<Resource> getResources(String sourcelanguageSlug, String projectSlug);
+
+    /**
+     * Returns a catalog
+     *
+     * @param catalogSlug
+     * @return the catalog object or null if it does not exist
+     */
+    Catalog getCatalog(String catalogSlug);
+
+    /**
+     * Returns a list of catalogs
+     *
+     * @return
+     */
+    List<Catalog> getCatalogs();
+
+    /**
+     * Returns a versification
+     *
+     * @param sourceLanguageSlug the language code for which the versification will be returned
+     * @param versificationSlug
+     * @return versification or null
+     */
+    Versification getVersification(String sourceLanguageSlug, String versificationSlug);
+
+    /**
+     * Returns a list of versifications
+     *
+     * @param sourceLanguageSlug the language code for which versifications will be returned
+     * @return
+     */
+    List<Versification> getVersifications(String sourceLanguageSlug);
+
+    /**
+     * Returns a list of chunk markers for a project
+     *
+     * @param projectSlug
+     * @param versificationSlug
+     * @return
+     */
+    List<ChunkMarker> getChunkMarkers(String projectSlug, String versificationSlug);
+
+    /**
+     * Returns a questionnaire
+     * @param tdId the translation database id (on the server) of the questionnaire
+     * @return
+     */
+    Questionnaire getQuestionnaire(long tdId);
+
+    /**
+     * Returns a list of questionnaires
+     *
+     * @return a list of questionnaires
+     */
+    List<Questionnaire> getQuestionnaires();
+
+    /**
+     * Returns a list of questions in the questionnaire
+     *
+     * @param questionnaireTDId the parent questionnaire translation database id (server side)
+     * @return a list of questions
+     */
+    List<Question> getQuestions(long questionnaireTDId);
+
+    /**
+     * Returns the category with it's localized title.
+     * This will return null if there is no matching localized category.
+     * This does not necessarily mean the category does not exist.
+     *
+     * @param languageSlug the language slug in which the category title will be given
+     * @param slug the category slug
+     * @return the category or null
+     */
+    Category getCategory(String languageSlug, String slug);
+
+    /**
+     * Returns a list of categories in a project
+     *
+     * @param languageSlug the language in which the category title will be given
+     * @param projectSlug the project slug
+     * @return a list of categories in the project
+     */
+    List<Category> getCategories(String languageSlug, String projectSlug);
+}

--- a/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
+++ b/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
@@ -28,7 +28,7 @@ import java.util.Map;
 class LegacyTools {
 
     /** Defines a configurable languages URL to be used when updating catalogs */
-    private static String LANG_NAMES_URL = "https://langnames-temp.walink.org/langnames.json";
+    private static String LANG_NAMES_URL = "https://langnames.bibleineverylanguage.org/langnames.json";
 
     /**
      *

--- a/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
+++ b/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
@@ -28,7 +28,7 @@ import java.util.Map;
 class LegacyTools {
 
     /** Defines a configurable languages URL to be used when updating catalogs */
-    public static String LANG_NAMES_URL = "https://langnames-temp.walink.org/langnames.json";
+    private static String LANG_NAMES_URL = "https://langnames-temp.walink.org/langnames.json";
 
     /**
      *
@@ -61,6 +61,8 @@ class LegacyTools {
         // tA
         updateTA(library, listener);
     }
+
+    public static void setLangNamesUrl(String url) { LANG_NAMES_URL = url; }
 
     /**
      * Pads a slug to 2 significant digits.

--- a/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
+++ b/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
@@ -1,0 +1,450 @@
+package org.unfoldingword.door43client;
+
+import org.json.JSONArray;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unfoldingword.door43client.models.Catalog;
+import org.unfoldingword.door43client.models.Category;
+import org.unfoldingword.door43client.models.ChunkMarker;
+import org.unfoldingword.door43client.models.SourceLanguage;
+import org.unfoldingword.door43client.models.Versification;
+import org.unfoldingword.resourcecontainer.ContainerTools;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+import org.unfoldingword.tools.http.GetRequest;
+
+import java.io.IOException;
+import java.net.URL;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Created by joel on 9/19/16.
+ */
+class LegacyTools {
+
+    /**
+     *
+     * @param library
+     * @param host the host to use for the catalogs
+     * @throws Exception
+     */
+    public static void injectGlobalCatalogs(Library library, String host) throws Exception {
+        host = host != null && !host.trim().isEmpty() ? host : "https://td.unfoldingword.org";
+
+        library.addCatalog(new Catalog("langnames", host + "/exports/langnames.json", 0));
+        // TRICKY: the trailing / is required on these urls
+        library.addCatalog(new Catalog("new-language-questions", host + "/api/questionnaire/", 0));
+        library.addCatalog(new Catalog("temp-langnames", host + "/api/templanguages/", 0));
+        // TRICKY: this catalog should always be indexed after langnames and temp-langnames otherwise the linking will fail!
+        library.addCatalog(new Catalog("approved-temp-langnames", host + "/api/templanguages/assignment/changed/", 0));
+    }
+
+    public static void processCatalog(Library library, String data, OnProgressListener listener) throws Exception {
+        JSONArray projects = new JSONArray(data);
+        for(int i = 0; i < projects.length(); i ++) {
+            JSONObject pJson = projects.getJSONObject(i);
+            if(listener != null) {
+                if(!listener.onProgress(pJson.getString("slug"), projects.length(), i + 1)) break;
+            }
+            downloadSourceLanguages(library, pJson, null);
+            library.yieldSafely();
+        }
+
+        // tA
+        updateTA(library, listener);
+    }
+
+    /**
+     * Pads a slug to 2 significant digits.
+     * Examples:
+     * '1'    -> '01'
+     * '001'  -> '01'
+     * '12'   -> '12'
+     * '123'  -> '123'
+     * '0123' -> '123'
+     * Words are not padded:
+     * 'a' -> 'a'
+     * '0word' -> '0word'
+     * And as a matter of consistency:
+     * '0'  -> '00'
+     * '00' -> '00'
+     *
+     * @param slug the slug to be normalized
+     * @return the normalized slug
+     */
+    public static String normalizeSlug(String slug) throws Exception {
+        if(slug == null || slug.isEmpty()) throw new Exception("slug cannot be an empty string");
+        if(!isInteger(slug)) return slug;
+        slug = slug.replaceAll("^(0+)", "").trim();
+        while(slug.length() < 2) {
+            slug = "0" + slug;
+        }
+        return slug;
+    }
+
+    /**
+     * Checks if a string is an integer
+     * @param s
+     * @return
+     */
+    protected static boolean isInteger(String s) {
+        try {
+            Integer.parseInt(s);
+        } catch(NumberFormatException e) {
+            return false;
+        } catch(NullPointerException e) {
+            return false;
+        }
+        return true;
+    }
+
+    /**
+     * Downloads the tA projects
+     * @param library
+     * @param listener
+     * @throws Exception
+     */
+    private static void updateTA(Library library, OnProgressListener listener) throws Exception {
+        String[] urls = new String[]{
+                "https://api.unfoldingword.org/ta/txt/1/en/audio_2.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/checking_1.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/checking_2.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/gateway_3.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/intro_1.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/process_1.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/translate_1.json",
+                "https://api.unfoldingword.org/ta/txt/1/en/translate_2.json"
+        };
+        for(int i = 0; i < urls.length; i ++) {
+            downloadTA(library, urls[i]);
+            if(listener != null) {
+                if(!listener.onProgress("ta", urls.length, i + 1)) break;
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Downloads the tA projects
+     * Continues from updateTA()
+     *
+     * @param library
+     * @param url
+     * @throws Exception
+     */
+    private static void downloadTA(Library library, String url) throws Exception {
+        GetRequest get = new GetRequest(new URL(url));
+        String data = get.read();
+        if(get.getResponseCode() != 200) throw new Exception(get.getResponseMessage());
+        JSONObject ta = new JSONObject(data);
+
+        // add language (right now only english)
+        long languageId = library.addSourceLanguage(new SourceLanguage("en", "English", "ltr"));
+
+        // add project
+        String rawSlug = ta.getJSONObject("meta").getString("manual").replaceAll("\\_", "-");
+        String name  = (rawSlug.charAt(0) + "").toUpperCase() + rawSlug.substring(1) + " Manual";
+        Project p = new Project("ta-" + rawSlug, name, 0);
+        List<Category> categories = new ArrayList<>();
+        categories.add(new Category("ta", "translationAcademy"));
+        long projectId = library.addProject(p, categories, languageId);
+
+        // add resource
+        String slug = "vol " + ta.getJSONObject("meta").getString("volume");
+        String resourceName = "Volume " + ta.getJSONObject("meta").getString("volume");
+        String type = new String("man");
+
+        // compile status
+        String checkingLevel = ta.getJSONObject("meta").getJSONObject("status").getString("checking_level");
+        String comments = ta.getJSONObject("meta").getJSONObject("status").getString("comments");
+        String pubDate = ta.getJSONObject("meta").getJSONObject("status").getString("publish_date");
+        String license = ta.getJSONObject("meta").getJSONObject("status").getString("license");
+        String version = ta.getJSONObject("meta").getJSONObject("status").getString("version");
+
+        Resource resource = new Resource(slug, resourceName, type, "gl", checkingLevel, version);
+        resource.comments = comments;
+        resource.pubDate = pubDate;
+        resource.license = license;
+
+        String packageVersion = ResourceContainer.version;
+        String mimType = ContainerTools.typeToMime("man");
+        int modifiedAt = ta.getJSONObject("meta").getInt("mod");
+        Resource.Format resourceFormat = new Resource.Format(packageVersion, mimType, modifiedAt, url, false);
+
+        resource.addFormat(resourceFormat);
+        library.addResource(resource, projectId);
+    }
+
+    /**
+     * This will download the source languages for a project.
+     * Some of the project info is mixed with languages
+     * so we are creating the projects and langauges here
+     *
+     * @param library
+     * @param pJson the project json
+     * @param listener
+     * @throws Exception
+     */
+    private static void downloadSourceLanguages(Library library, JSONObject pJson, OnProgressListener listener) throws Exception {
+        GetRequest request = new GetRequest(new URL(pJson.getString("lang_catalog")));
+        String response = request.read();
+        if(request.getResponseCode() != 200) throw new Exception(request.getResponseMessage());
+
+        String chunksUrl = "";
+        if(!pJson.getString("slug").toLowerCase().equals("obs")) {
+            chunksUrl = "https://api.unfoldingword.org/bible/txt/1/" + pJson.getString("slug") + "/chunks.json";
+        }
+
+        JSONArray languages = new JSONArray(response);
+        for(int i = 0; i < languages.length(); i ++) {
+            JSONObject lJson = languages.getJSONObject(i);
+
+            if(listener != null) {
+                if(!listener.onProgress(lJson.getJSONObject("language").getString("slug") + pJson.getString("slug"), languages.length(), i + 1)) break;
+            }
+
+            SourceLanguage sl = new SourceLanguage(lJson.getJSONObject("language").getString("slug"),
+                    lJson.getJSONObject("language").getString("name"),
+                    lJson.getJSONObject("language").getString("direction"));
+            long languageId = library.addSourceLanguage(sl);
+
+            // TODO: retrieve the correct versification name(s) from the source language
+            library.addVersification(new Versification("en-US", "American English"), languageId);
+
+            Project project = new Project(pJson.getString("slug"),
+                    lJson.getJSONObject("project").getString("name"),
+                    pJson.getInt("sort"));
+            project.description = lJson.getJSONObject("project").getString("desc");
+            project.chunksUrl = chunksUrl;
+            List<Category> categories = new ArrayList<>();
+            if(pJson.has("meta")) {
+                for(int j = 0; j < pJson.getJSONArray("meta").length(); j ++) {
+                    String slug = pJson.getJSONArray("meta").getString(j);
+                    categories.add(new Category(slug, lJson.getJSONObject("project").getJSONArray("meta").getString(j)));
+                }
+            }
+
+            long projectId = library.addProject(project, categories, languageId);
+
+            downloadResources(library, projectId, pJson, languageId, lJson);
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Downloads resources for a project.
+     * This will split notes and questions into their own resource.
+     * words are added as a new project.
+     *
+     * @param library
+     * @param projectId
+     * @param pJson
+     * @param languageId
+     * @param lJson
+     * @throws Exception
+     */
+    private static void downloadResources(Library library, long projectId, JSONObject pJson, long languageId, JSONObject lJson) throws Exception {
+        GetRequest request = new GetRequest(new URL(lJson.getString("res_catalog")));
+        String response = request.read();
+        if(request.getResponseCode() != 200) throw new Exception(request.getResponseMessage());
+
+        JSONArray resources = new JSONArray(response);
+        for(int i = 0; i < resources.length(); i ++) {
+            JSONObject rJson = resources.getJSONObject(i);
+
+            String translateMode;
+            switch(rJson.getString("slug").toLowerCase()) {
+                case "obs":
+                case "ulb":
+                    translateMode = "all";
+                    break;
+                default:
+                    translateMode = "gl";
+            }
+
+            rJson.getJSONObject("status").put("translate_mode", translateMode);
+            rJson.getJSONObject("status").put("pub_date", rJson.getJSONObject("status").getString("publish_date"));
+            rJson.put("type", "book");
+            Resource resource = Resource.fromJSON(rJson);
+            resource._legacyData.put(API.LEGACY_WORDS_ASSIGNMENTS_URL, rJson.getString("tw_cat"));
+
+            Resource.Format format = new Resource.Format(ResourceContainer.version, ContainerTools.typeToMime("book"), rJson.getInt("date_modified"), rJson.getString("source"), false);
+            resource.addFormat(format);
+
+            long resourceId = library.addResource(resource, projectId);
+
+            // coerce notes to resource
+            if(rJson.has("notes") && !rJson.getString("notes").isEmpty()) {
+                rJson.getJSONObject("status").put("translate_mode", "gl");
+                rJson.put("slug", "tn");
+                rJson.put("name", "translationNotes");
+                rJson.put("type", "help");
+                List<Map> sourceTranslations = new ArrayList();
+                Map<String, Object> tnSourceTranslation = new HashMap();
+                tnSourceTranslation.put("language_slug", lJson.getJSONObject("language").getString("slug"));
+                tnSourceTranslation.put("resource_slug", "tn");
+                tnSourceTranslation.put("version", resource.version);
+                sourceTranslations.add(tnSourceTranslation);
+                rJson.getJSONObject("status").put("source_translations", sourceTranslations);
+
+                Resource tnResource = (Resource) Resource.fromJSON(rJson);
+                Resource.Format tnFormat = new Resource.Format(ResourceContainer.version, ContainerTools.typeToMime("help"), rJson.getInt("date_modified"), rJson.getString("notes"), false);
+                tnResource.addFormat(tnFormat);
+                library.addResource(tnResource, projectId);
+            }
+
+            // coerce questions to resource
+            if(rJson.has("checking_questions") && !rJson.getString("checking_questions").isEmpty()) {
+                rJson.getJSONObject("status").put("translate_mode", "gl");
+                rJson.put("slug", "tq");
+                rJson.put("name", "translationQuestions");
+                rJson.put("type", "help");
+
+                List<Map> sourceTranslations = new ArrayList();
+                Map<String, Object> tnSourceTranslation = new HashMap();
+                tnSourceTranslation.put("language_slug", lJson.getJSONObject("language").getString("slug"));
+                tnSourceTranslation.put("resource_slug", "tq");
+                tnSourceTranslation.put("version", resource.version);
+                sourceTranslations.add(tnSourceTranslation);
+                rJson.getJSONObject("status").put("source_translations", sourceTranslations);
+
+                Resource tqResource = (Resource) Resource.fromJSON(rJson);
+                Resource.Format tqFormat = new Resource.Format(ResourceContainer.version, ContainerTools.typeToMime("help"), rJson.getInt("date_modified"), rJson.getString("checking_questions"), false);
+                tqResource.addFormat(tqFormat);
+                library.addResource(tqResource, projectId);
+            }
+
+            // add words project (this is insert/update so it will only be added once)
+            // TRICKY: obs tw has not been unified with bible tw yet so we add it as separate project.
+            if(rJson.has("terms") && !rJson.getString("terms").isEmpty()) {
+                String slug = pJson.getString("slug").equals("obs") ? "bible-obs" : "bible";
+                String name = "translationWords" + (pJson.getString("slug").equals("obs") ? " OBS" : "");
+                Project wordsProject = new Project(slug, name, 100);
+                long wordsProjectId = library.addProject(wordsProject, null, languageId);
+
+                // add resource to words project
+                rJson.getJSONObject("status").put("translate_mode", "gl");
+                rJson.put("slug", "tw");
+                rJson.put("name", "translationWords");
+                rJson.put("type", "dict");
+
+                List<Map> sourceTranslations = new ArrayList();
+                Map<String, Object> twSourceTranslation = new HashMap();
+                twSourceTranslation.put("language_slug", lJson.getJSONObject("language").getString("slug"));
+                twSourceTranslation.put("resource_slug", "tw");
+                twSourceTranslation.put("version", resource.version);
+                sourceTranslations.add(twSourceTranslation);
+                rJson.getJSONObject("status").put("source_translations", sourceTranslations);
+
+                Resource twResource = (Resource) Resource.fromJSON(rJson);
+                Resource.Format twFormat = new Resource.Format(ResourceContainer.version, ContainerTools.typeToMime("dict"), rJson.getInt("date_modified"), rJson.getString("terms"), false);
+                twResource.addFormat(twFormat);
+                library.addResource(twResource, wordsProjectId);
+            }
+            library.yieldSafely();
+        }
+    }
+
+    /**
+     * Downloads chunks for a project
+     * @param library
+     * @param chunksUrl
+     * @param projectSlug
+     * @throws Exception
+     */
+    private static void downloadChunks(Library library, String chunksUrl, String projectSlug) throws Exception {
+        // TODO: pull the correct versification slug from the data. For now there is only one versification
+        Versification v = library.getVersification("en", "en-US");
+        if(v != null) {
+            GetRequest request = new GetRequest(new URL(chunksUrl));
+            String data = request.read();
+            JSONArray chunks = new JSONArray(data);
+            for(int i = 0; i < chunks.length(); i ++) {
+                JSONObject chunk = chunks.getJSONObject(i);
+                ChunkMarker cm = new ChunkMarker(chunk.getString("chp"), chunk.getString("firstvs"));
+                library.addChunkMarker(cm, projectSlug, v.rowId);
+                library.yieldSafely();
+            }
+        } else {
+            System.console().writer().write("Unknown versification while downloading chunks for project " + projectSlug);
+        }
+    }
+
+    /**
+     * Converts a json object to a hash map
+     * http://stackoverflow.com/questions/21720759/convert-a-json-string-to-a-hashmap
+     * @param json
+     * @return
+     * @throws JSONException
+     */
+    public static Map<String, Object> jsonToMap(JSONObject json) throws JSONException {
+        Map<String, Object> retMap = new HashMap<String, Object>();
+
+        if(json != JSONObject.NULL) {
+            retMap = toMap(json);
+        }
+        return retMap;
+    }
+
+    public static Map<String, Object> toMap(JSONObject object) throws JSONException {
+        Map<String, Object> map = new HashMap<String, Object>();
+
+        Iterator<String> keysItr = object.keys();
+        while(keysItr.hasNext()) {
+            String key = keysItr.next();
+            Object value = object.get(key);
+
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            map.put(key, value);
+        }
+        return map;
+    }
+
+    public static List<Object> toList(JSONArray array) throws JSONException {
+        List<Object> list = new ArrayList<Object>();
+        for(int i = 0; i < array.length(); i++) {
+            Object value = array.get(i);
+            if(value instanceof JSONArray) {
+                value = toList((JSONArray) value);
+            }
+
+            else if(value instanceof JSONObject) {
+                value = toMap((JSONObject) value);
+            }
+            list.add(value);
+        }
+        return list;
+    }
+
+    public static void processChunks(Library library, OnProgressListener listener) throws Exception {
+        // TRICKY: currently all chunk markers are defined according to the english versification system
+        Map<String, String> markers = new HashMap<>();
+        for(SourceLanguage l:library.getSourceLanguages()) {
+            for(Project p:library.getProjects(l.slug)) {
+                if(p.chunksUrl != null && !p.chunksUrl.isEmpty()) {
+                    markers.put(p.slug, p.chunksUrl);
+                }
+            }
+        }
+
+        int pos = 0;
+        for(String key:markers.keySet()) {
+            downloadChunks(library, markers.get(key), key);
+            pos ++;
+            if(listener != null) {
+                if(!listener.onProgress("chunk_markers", markers.size(), pos)) break;
+            }
+        }
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
+++ b/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
@@ -36,7 +36,7 @@ class LegacyTools {
     public static void injectGlobalCatalogs(Library library, String host) throws Exception {
         host = host != null && !host.trim().isEmpty() ? host : "https://td.unfoldingword.org";
 
-        library.addCatalog(new Catalog("langnames", host + "/exports/langnames.json", 0));
+        library.addCatalog(new Catalog("langnames", "https://langnames-temp.walink.org/langnames.json", 0));
         // TRICKY: the trailing / is required on these urls
         library.addCatalog(new Catalog("new-language-questions", host + "/api/questionnaire/", 0));
         library.addCatalog(new Catalog("temp-langnames", host + "/api/templanguages/", 0));

--- a/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
+++ b/app/src/main/java/org/unfoldingword/door43client/LegacyTools.java
@@ -27,6 +27,9 @@ import java.util.Map;
  */
 class LegacyTools {
 
+    /** Defines a configurable languages URL to be used when updating catalogs */
+    public static String LANG_NAMES_URL = "https://langnames-temp.walink.org/langnames.json";
+
     /**
      *
      * @param library
@@ -36,7 +39,7 @@ class LegacyTools {
     public static void injectGlobalCatalogs(Library library, String host) throws Exception {
         host = host != null && !host.trim().isEmpty() ? host : "https://td.unfoldingword.org";
 
-        library.addCatalog(new Catalog("langnames", "https://langnames-temp.walink.org/langnames.json", 0));
+        library.addCatalog(new Catalog("langnames", LANG_NAMES_URL, 0));
         // TRICKY: the trailing / is required on these urls
         library.addCatalog(new Catalog("new-language-questions", host + "/api/questionnaire/", 0));
         library.addCatalog(new Catalog("temp-langnames", host + "/api/templanguages/", 0));

--- a/app/src/main/java/org/unfoldingword/door43client/Library.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Library.java
@@ -5,7 +5,8 @@ import android.database.Cursor;
 import android.database.SQLException;
 import android.database.sqlite.SQLiteDatabase;
 
-import org.jetbrains.annotations.Nullable;
+import androidx.annotation.Nullable;
+
 import org.json.JSONException;
 import org.json.JSONObject;
 import org.unfoldingword.door43client.models.Category;

--- a/app/src/main/java/org/unfoldingword/door43client/Library.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Library.java
@@ -1,0 +1,1619 @@
+package org.unfoldingword.door43client;
+
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.database.SQLException;
+import android.database.sqlite.SQLiteDatabase;
+
+import org.jetbrains.annotations.Nullable;
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unfoldingword.door43client.models.Category;
+import org.unfoldingword.door43client.models.CategoryEntry;
+import org.unfoldingword.door43client.models.ChunkMarker;
+import org.unfoldingword.door43client.models.TargetLanguage;
+import org.unfoldingword.door43client.models.Question;
+import org.unfoldingword.door43client.models.SourceLanguage;
+import org.unfoldingword.door43client.models.Translation;
+import org.unfoldingword.door43client.models.Versification;
+import org.unfoldingword.door43client.models.Catalog;
+import org.unfoldingword.door43client.models.Questionnaire;
+import org.unfoldingword.resourcecontainer.ContainerTools;
+import org.unfoldingword.resourcecontainer.Language;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+
+import java.io.File;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+
+
+/**
+ * Manages the indexed library content.
+ */
+class Library implements Index {
+
+    private final SQLiteHelper sqliteHelper;
+    private final SQLiteDatabase db;
+
+    /**
+     * Instantiates a new library
+     * @param sqliteHelper
+     */
+    public Library(SQLiteHelper sqliteHelper) throws IOException {
+        this.sqliteHelper = sqliteHelper;
+        this.db = sqliteHelper.getWritableDatabase();
+        if(this.db.getVersion() == 0) throw new IOException("Invalid database version." +
+                "You probably manually generted the database and forgot to set the " +
+                "\"User Version\" to " + SQLiteHelper.DATABASE_VERSION);
+    }
+
+    /**
+     * Temporary ends the transaction to let other threads run
+     */
+    public void  yieldSafely() {
+        db.yieldIfContendedSafely();
+    }
+
+    /**
+     * Used to open a transaction
+     */
+    public void beginTransaction() {
+        db.beginTransactionNonExclusive();
+    }
+
+    /**
+     * Used to close a transaction
+     * @param success set to false if the transaction should fail and the changes rolled back.
+     */
+    public void endTransaction(boolean success) {
+        if(success) {
+            db.setTransactionSuccessful();
+        }
+        db.endTransaction();
+    }
+
+    /**
+     * Closes the database
+     */
+    public void closeDatabase() {
+        sqliteHelper.close();
+    }
+
+    /**
+     * Ensures a value is not null or empty
+     * @param value
+     * @throws Exception
+     */
+    private void validateNotEmpty(String value) throws Exception {
+        if(value == null || value.trim().isEmpty()) throw new Exception("Invalid parameter value");
+    }
+
+    /**
+     * Converts null strings to empty strings
+     * @param value
+     * @return
+     */
+    private String deNull(String value) {
+        return value == null ? "" : value;
+    }
+
+    /**
+     * Attempts to insert a row.
+     *
+     * There is a bug in the SQLiteDatabase API that prevents us from using insertWithOnConflict + CONFLICT_IGNORE
+     * https://code.google.com/p/android/issues/detail?id=13045
+     * @param table
+     * @param values
+     * @param uniqueColumns
+     * @return the id of the inserted row or the id of the existing row.
+     */
+    synchronized private InsertResult insertOrIgnore(String table, ContentValues values, String[] uniqueColumns) {
+        // try to insert
+        Exception error = null;
+        try {
+            long id = db.insertOrThrow(table, null, values);
+            return new InsertResult(id, true);
+        } catch (SQLException e) {
+            error = e;
+        }
+        long id = -1;
+
+        WhereClause where = WhereClause.prepare(values, uniqueColumns);
+
+        Cursor cursor = null;
+        try {
+            cursor = db.rawQuery("select id from " + table + " where " + where.statement, where.arguments);
+            if (cursor.moveToFirst()) {
+                id = cursor.getLong(0);
+                cursor.close();
+            } else {
+                cursor.close();
+            }
+        } catch (Exception e) {
+            e.printStackTrace();
+            if(cursor != null) cursor.close();
+        }
+
+        // TRICKY: print the insert stacktrace only if the select failed.
+        if(error != null && id == -1) error.printStackTrace();
+        return new InsertResult(id, false);
+    }
+
+    /**
+     * A utility to perform insert+update operations.
+     * Insert failures are ignored.
+     * Update failures are thrown.
+     *
+     * @param table
+     * @param values
+     * @param uniqueColumns an array of unique columns on this table. This should be a subset of the values.
+     * @return the id of the inserted/updated row
+     */
+    synchronized private InsertResult insertOrUpdate(String table, ContentValues values, String[] uniqueColumns) throws Exception {
+        // insert
+        InsertResult result = insertOrIgnore(table, values, uniqueColumns);
+        if(!result.inserted) {
+            WhereClause where = WhereClause.prepare(values, uniqueColumns);
+
+            // clean values
+            for(String key:uniqueColumns) {
+                values.remove(key);
+            }
+
+            // update
+            int numRows = db.updateWithOnConflict(table, values, where.statement, where.arguments, SQLiteDatabase.CONFLICT_ROLLBACK);
+            if(numRows == 0) {
+                throw new Exception("Failed to update the row in " + table);
+            } else {
+                // retrieve updated row id
+                Cursor cursor = db.rawQuery("select id from " + table + " where " + where.statement, where.arguments);
+                if(cursor.moveToFirst()) {
+                    long id = cursor.getLong(0);
+                    cursor.close();
+                    return new InsertResult(id, false);
+                } else {
+                    cursor.close();
+                    throw new Exception("Failed to find the row in " + table);
+                }
+            }
+        } else {
+            return result;
+        }
+    }
+
+    /**
+     * Inserts or updates a source language in the library.
+     *
+     * @param language
+     * @return the id of the source language row
+     * @throws Exception
+     */
+    public long addSourceLanguage(SourceLanguage language) throws Exception {
+        validateNotEmpty(language.slug);
+        validateNotEmpty(language.name);
+        validateNotEmpty(language.direction);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", language.slug);
+        values.put("name", language.name);
+        values.put("direction", language.direction);
+
+        return insertOrUpdate("source_language", values, new String[]{"slug"}).id;
+    }
+
+    /**
+     * Inserts or updates a target language in the library.
+     *
+     * Note: the result is boolean since you don't need the row id. See getTargetLanguages for more information
+     *
+     * @param language
+     * @return
+     * @throws Exception
+     */
+    public boolean addTargetLanguage(TargetLanguage language) throws Exception {
+        validateNotEmpty(language.slug);
+        validateNotEmpty(language.name);
+        validateNotEmpty(language.direction);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", language.slug);
+        values.put("name", language.name);
+        values.put("direction", language.direction);
+        values.put("anglicized_name", deNull(language.anglicizedName));
+        values.put("region", deNull(language.region));
+        values.put("is_gateway_language", language.isGatewayLanguage ? 1: 0);
+
+        long id = insertOrUpdate("target_language", values, new String[]{"slug"}).id;
+        return id > 0;
+    }
+
+    public boolean addTempTargetLanguage(TargetLanguage language) throws Exception {
+        validateNotEmpty(language.slug);
+        validateNotEmpty(language.name);
+        validateNotEmpty(language.direction);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", language.slug);
+        values.put("name", language.name);
+        values.put("direction", language.direction);
+        values.put("anglicized_name", deNull(language.anglicizedName));
+        values.put("region", deNull(language.region));
+        values.put("is_gateway_language", language.isGatewayLanguage ? 1 : 0);
+
+        long id = insertOrUpdate("temp_target_language", values, new String[]{"slug"}).id;
+        return id > 0;
+    }
+
+    /**
+     * Updates the target language assigned to a temporary target language
+     * @param tempTargetLanguageSlug the temporary target language that is being assigned a target language
+     * @param targetLanguageSlug the assigned target language
+     * @return indicates if the approved language was successfully set
+     */
+    public boolean setApprovedTargetLanguage(String tempTargetLanguageSlug, String targetLanguageSlug) throws Exception {
+        validateNotEmpty(tempTargetLanguageSlug);
+        validateNotEmpty(targetLanguageSlug);
+
+        ContentValues contentValues = new ContentValues();
+        contentValues.put("approved_target_language_slug", targetLanguageSlug);
+
+        int rowsAffected = db.updateWithOnConflict("temp_target_language", contentValues,
+                "slug=?", new String[]{tempTargetLanguageSlug}, SQLiteDatabase.CONFLICT_IGNORE );
+
+        return rowsAffected > 0;
+    }
+
+    /**
+     * Inserts or updates a project in the library
+     *
+     * @param project
+     * @param categories this is the category branch that the project will attach to
+     * @param sourceLanguageId the parent source language row id
+     * @return the id of the project row
+     * @throws Exception
+     */
+    public long addProject(Project project, List<Category> categories, long sourceLanguageId) throws Exception {
+        validateNotEmpty(project.slug);
+        validateNotEmpty(project.name);
+
+        // add categories
+        long parentCategoryId = 0;
+        if(categories != null) {
+            // build categories
+            for(Category category:categories) {
+                validateNotEmpty(category.slug);
+                validateNotEmpty(category.name);
+
+                ContentValues insertValues = new ContentValues();
+                insertValues.put("slug", category.slug);
+                insertValues.put("parent_id", parentCategoryId);
+
+                long id = insertOrIgnore("category", insertValues, new String[]{"slug", "parent_id"}).id;
+                if(id > 0) {
+                    parentCategoryId = id;
+                } else {
+                    throw new Exception("Invalid category");
+                }
+
+                ContentValues updateValues = new ContentValues();
+                updateValues.put("source_language_id", sourceLanguageId);
+                updateValues.put("category_id", parentCategoryId);
+                updateValues.put("name", category.name);
+
+                insertOrUpdate("category_name", updateValues, new String[]{"source_language_id", "category_id"});
+            }
+        }
+        // add project
+        ContentValues updateProject = new ContentValues();
+        updateProject.put("slug", project.slug);
+        updateProject.put("name", project.name);
+        updateProject.put("desc", deNull(project.description));
+        updateProject.put("icon", deNull(project.icon));
+        updateProject.put("sort", project.sort);
+        updateProject.put("chunks_url", deNull(project.chunksUrl));
+        updateProject.put("source_language_id", sourceLanguageId);
+        updateProject.put("category_id", parentCategoryId);
+
+        return insertOrUpdate("project", updateProject, new String[]{"slug", "source_language_id"}).id;
+    }
+
+    /**
+     * Inserts or updates a versification in the library.
+     *
+     * @param versification
+     * @param sourceLanguageId the parent source language row id
+     * @return the id of the versification or -1
+     * @throws Exception
+     */
+    public long addVersification(Versification versification, long sourceLanguageId) throws Exception{
+        validateNotEmpty(versification.slug);
+        validateNotEmpty(versification.name);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", versification.slug);
+
+        long versificationId = insertOrIgnore("versification", values, new String[]{"slug"}).id;
+        if(versificationId > 0) {
+            ContentValues cv = new ContentValues();
+            cv.put("source_language_id", sourceLanguageId);
+            cv.put("versification_id", versificationId);
+            cv.put("name", versification.name);
+            insertOrUpdate("versification_name", cv, new String[]{"source_language_id", "versification_id"});
+        } else {
+            throw new Exception("Invalid versification");
+        }
+        return versificationId;
+    }
+
+    /**
+     * Inserts a chunk marker in the library.
+     *
+     * @param chunk
+     * @param projectSlug the project that this marker exists in
+     * @param versificationId the versification this chunk is a member of
+     * @return the id of the chunk marker
+     * @throws Exception
+     */
+    public long addChunkMarker(ChunkMarker chunk, String projectSlug, long versificationId) throws Exception {
+        validateNotEmpty(chunk.chapter);
+        validateNotEmpty(chunk.verse);
+        validateNotEmpty(projectSlug);
+
+        ContentValues chunkValues = new ContentValues();
+        chunkValues.put("chapter", chunk.chapter);
+        chunkValues.put("verse", chunk.verse);
+        chunkValues.put("project_slug", projectSlug);
+        chunkValues.put("versification_id", versificationId);
+
+        long id = insertOrIgnore("chunk_marker", chunkValues, new String[]{"project_slug", "versification_id", "chapter", "verse"}).id;
+        if(id == -1) {
+            throw new Exception("Invalid Chunk Marker");
+        }
+        return id;
+    }
+
+    /**
+     * Inserts or updates a catalog in the library.
+     *
+     * @param catalog
+     * @return the id of the catalog
+     * @throws Exception
+     */
+    public long addCatalog(Catalog catalog) throws Exception{
+        validateNotEmpty(catalog.slug);
+        validateNotEmpty(catalog.url);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", catalog.slug);
+        values.put("url", catalog.url);
+        values.put("modified_at", catalog.modifiedAt);
+
+        return insertOrUpdate("catalog", values, new String[]{"slug"}).id;
+    }
+
+    /**
+     * Inserts or updates a resource in the library.
+     *
+     * @param resource the resource being indexed
+     * @param projectId the parent project row id
+     * @return the id of the resource row
+     * @throws Exception
+     */
+    public long addResource(Resource resource, long projectId) throws Exception {
+        validateNotEmpty(resource.slug);
+        validateNotEmpty(resource.name);
+        validateNotEmpty(resource.type);
+        validateNotEmpty(resource.formats.size() > 0 ? "good" : null);
+        validateNotEmpty(resource.translateMode);
+        validateNotEmpty(resource.checkingLevel);
+        validateNotEmpty(resource.version);
+
+        ContentValues values = new ContentValues();
+        values.put("slug", resource.slug);
+        values.put("name", resource.name);
+        values.put("type", resource.type);
+        values.put("translate_mode", resource.translateMode);
+        values.put("checking_level", resource.checkingLevel);
+        values.put("comments", deNull(resource.comments));
+        values.put("pub_date", deNull(resource.pubDate));
+        values.put("license", deNull(resource.license));
+        values.put("version", resource.version);
+        values.put("project_id", projectId);
+
+        long resourceId = insertOrUpdate("resource", values, new String[]{"slug", "project_id"}).id;
+
+        // add formats
+        for(Resource.Format format : resource.formats) {
+            validateNotEmpty(format.mimeType);
+            ContentValues formatValues = new ContentValues();
+            formatValues.put("package_version", format.packageVersion);
+            formatValues.put("mime_type", format.mimeType);
+            formatValues.put("imported", format.imported ? 1 : 0);
+            formatValues.put("modified_at", format.modifiedAt);
+            formatValues.put("url", deNull(format.url));
+            formatValues.put("resource_id", resourceId);
+
+            insertOrUpdate("resource_format", formatValues, new String[]{"mime_type", "resource_id"});
+        }
+
+        //add legacy data
+        if(resource._legacyData.containsKey(API.LEGACY_WORDS_ASSIGNMENTS_URL)
+                && resource._legacyData.get(API.LEGACY_WORDS_ASSIGNMENTS_URL) != null
+                && !resource._legacyData.get(API.LEGACY_WORDS_ASSIGNMENTS_URL).equals("")) {
+            ContentValues legacyValues = new ContentValues();
+            legacyValues.put("translation_words_assignments_url", (String)resource._legacyData.get(API.LEGACY_WORDS_ASSIGNMENTS_URL));
+            legacyValues.put("resource_id", resourceId);
+            insertOrUpdate("legacy_resource_info", legacyValues, new String[]{"resource_id"});
+        }
+        return resourceId;
+    }
+
+    /**
+     *Inserts or updates a questionnaire in the library.
+     *
+     * @param questionnaire the questionnaire to add
+     * @return the id of the questionnaire row
+     * @throws Exception
+     */
+    public long addQuestionnaire(Questionnaire questionnaire) throws Exception {
+        validateNotEmpty(questionnaire.languageSlug);
+        validateNotEmpty(questionnaire.languageName);
+        validateNotEmpty(questionnaire.languageDirection);
+
+        ContentValues values = new ContentValues();
+        values.put("language_slug", questionnaire.languageSlug);
+        values.put("language_name", questionnaire.languageName);
+        values.put("language_direction", questionnaire.languageDirection);
+        values.put("td_id", questionnaire.tdId);
+
+        long id = insertOrUpdate("questionnaire", values, new String[]{"td_id", "language_slug"}).id;
+
+        // add data fields
+        for(String field:questionnaire.dataFields.keySet()) {
+            ContentValues fieldValues = new ContentValues();
+            fieldValues.put("questionnaire_id", id);
+            fieldValues.put("field", field);
+            fieldValues.put("question_td_id", (long)questionnaire.dataFields.get(field));
+            insertOrUpdate("questionnaire_data_field", fieldValues, new String[]{"field", "questionnaire_id"});
+        }
+
+        return id;
+    }
+
+    /**
+     * Inserts or updates a question in the library.
+     *
+     * @param question the questionnaire to add
+     * @param questionnaireId the parent questionnaire row id
+     * @return the id of the question row
+     * @throws Exception
+     */
+    public long addQuestion(Question question, long questionnaireId) throws Exception {
+        validateNotEmpty(question.text);
+        validateNotEmpty(question.inputType == null ? "" : "ok");
+
+        ContentValues values = new ContentValues();
+        values.put("text", question.text);
+        values.put("help", deNull(question.help));
+        values.put("is_required", question.isRequired ? 1 : 0);
+        values.put("input_type", question.inputType.toString());
+        values.put("sort", question.sort);
+        values.put("depends_on", question.dependsOn);
+        values.put("td_id", question.tdId);
+        values.put("questionnaire_id", questionnaireId);
+
+        return insertOrUpdate("question", values, new String[]{"td_id", "questionnaire_id"}).id;
+    }
+
+    public List<HashMap> listSourceLanguagesLastModified() {
+        Cursor cursor = db.rawQuery("select sl.slug, max(rf.modified_at) as modified_at from resource_format as rf"
+                + " left join resource  as r on r.id=rf.resource_id"
+                + " left join project as p on p.id=r.project_id"
+                + " left join source_language as sl on sl.id=p.source_language_id"
+                + " where rf.mime_type like(\"" + ResourceContainer.baseMimeType + "+%\")"
+                + " group by sl.slug", null);
+        cursor.moveToFirst();
+        List<HashMap> langsLastModifiedList = new ArrayList<>();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            int modifiedAt = reader.getInt("modified_at");
+
+            HashMap sourceLanguageMap = new HashMap();
+            sourceLanguageMap.put(slug, modifiedAt);
+            langsLastModifiedList.add(sourceLanguageMap);
+        }
+        cursor.close();
+        return langsLastModifiedList;
+    }
+
+    public Map<String, Integer> listProjectsLastModified(String languageSlug) {
+        Cursor cursor = null;
+        if(languageSlug != null || languageSlug != ""){
+            cursor = db.rawQuery("select p.slug, max(rf.modified_at) as modified_at from resource_format as rf"
+                + " left join resource  as r on r.id=rf.resource_id"
+                + " left join project as p on p.id=r.project_id"
+                + " left join source_language as sl on sl.id=p.source_language_id"
+                + " where rf.mime_type like(\"" + ResourceContainer.baseMimeType + "+%\") and sl.slug=?"
+                + " group by p.slug", new String[]{languageSlug});
+        } else {
+            cursor = db.rawQuery("select p.slug, max(rf.modified_at) as modified_at from resource_format as rf"
+                + " left join resource  as r on r.id=rf.resource_id"
+                + " left join project as p on p.id=r.project_id"
+                + " left join source_language as sl on sl.id=p.source_language_id"
+                + " where rf.mime_type like(\"" + ResourceContainer.baseMimeType + "+%\") and sl.slug=?"
+                + " group by p.slug", null);
+        }
+        Map<String, Integer> projectsLastModifiedList = new HashMap();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+            projectsLastModifiedList.put(reader.getString("slug"), reader.getInt("modified_at"));
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return projectsLastModifiedList;
+    }
+
+    /**
+     * Returns meta data about a project without any localized information such as the title or description
+     * @param projectSlug the slug of the project who's meta will be returned
+     * @return the project meta data
+     */
+    public JSONObject getProjectMeta(String projectSlug) {
+        Cursor cursor = db.rawQuery("select * from project where slug=? limit 1", new String[]{projectSlug});
+        JSONObject meta = null;
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+            try {
+                meta = new JSONObject();
+                meta.put("slug", reader.getString("slug"));
+                meta.put("icon", reader.getString("icon"));
+                meta.put("sort", reader.getString("sort"));
+                meta.put("chunks_url", reader.getString("chunks_url"));
+                meta.put("category_id", reader.getString("category_id"));
+            } catch (JSONException e) {
+                e.printStackTrace();
+                meta = null;
+            }
+        }
+        cursor.close();
+        return meta;
+    }
+
+    public Translation getTranslation(String containerSlug) {
+        try {
+            String[] slugs = ContainerTools.explodeSlug(containerSlug);
+            SourceLanguage l = getSourceLanguage(slugs[0]);
+            Project p = getProject(slugs[0], slugs[1]);
+            Resource r = getResource(slugs[0], slugs[1], slugs[2]);
+            return new Translation(l, p, r);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+        return null;
+    }
+
+    public List<Translation> findTranslations(String languageSlug, String projectSlug, String resourceSlug, String resourceType, String translateMode, int minCheckingLevel, int maxCheckingLevel) {
+        String conditionMaxChecking = "";
+
+        if(languageSlug == null || languageSlug.isEmpty()) languageSlug = "%";
+        if(projectSlug == null || projectSlug.isEmpty()) projectSlug = "%";
+        if(resourceSlug == null || resourceSlug.isEmpty()) resourceSlug = "%";
+        if(resourceType == null || resourceType.isEmpty()) resourceType = "%";
+        if(translateMode == null || translateMode.isEmpty()) translateMode = "%";
+
+        if(maxCheckingLevel >= 0) conditionMaxChecking = " and r.checking_level <= " + maxCheckingLevel;
+
+        List<Translation> translations = new ArrayList<>();
+        Cursor cursor = db.rawQuery("select l.slug as language_slug, l.name as language_name, l.direction," +
+                " p.slug as project_slug, p.name as project_name, p.desc, p.icon, p.sort, p.chunks_url," +
+                " r.id as resource_id, r.slug as resource_slug, r.name as resource_name, r.type, r.translate_mode, r.checking_level, r.comments, r.pub_date, r.license, r.version," +
+                " lri.translation_words_assignments_url" +
+                " from source_language as l" +
+                " left join project as p on p.source_language_id=l.id" +
+                " left join (" +
+                "   select r.*, count(rf.id) as num_imported from resource as r" +
+                "   left join resource_format as rf on rf.resource_id=r.id and rf.imported='1'" +
+                "   group by r.id" +
+                " ) as r on r.project_id=p.id" +
+                " left join legacy_resource_info as lri on lri.resource_id=r.id" +
+                " where l.slug like(?) and p.slug like(?) and r.slug like(?)" +
+                " and (" +
+                "   (" +
+                "     r.checking_level >= " + minCheckingLevel + "" +
+                      conditionMaxChecking +
+                "     and r.translate_mode like(?)" +
+                "   )" +
+                "   or r.num_imported > 0" +
+                " )" +
+                " and r.type like(?)",
+                new String[]{languageSlug, projectSlug, resourceSlug, translateMode, resourceType});
+
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            Translation t = buildTranslation(new CursorReader(cursor));
+            translations.add(t);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return translations;
+    }
+
+    public List<Translation> getImportedTranslations() {
+        List<Translation> translations = new ArrayList<>();
+        Cursor cursor = db.rawQuery("select l.slug as language_slug, l.name as language_name, l.direction," +
+                        " p.slug as project_slug, p.name as project_name, p.desc, p.icon, p.sort, p.chunks_url," +
+                        " r.id as resource_id, r.slug as resource_slug, r.name as resource_name, r.type, r.translate_mode, r.checking_level, r.comments, r.pub_date, r.license, r.version," +
+                        " lri.translation_words_assignments_url" +
+                        " from source_language as l" +
+                        " left join project as p on p.source_language_id=l.id" +
+                        " left join (" +
+                        "   select r.*, count(rf.id) as num_imported from resource as r" +
+                        "   left join resource_format as rf on rf.resource_id=r.id and rf.imported='1'" +
+                        "   group by r.id" +
+                        " ) as r on r.project_id=p.id" +
+                        " left join legacy_resource_info as lri on lri.resource_id=r.id" +
+                        " where r.num_imported > 0",
+                new String[]{});
+
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            Translation t = buildTranslation(new CursorReader(cursor));
+            translations.add(t);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return translations;
+    }
+
+    /**
+     * Utility to build a new translation object from a db cursor reader
+     * @param reader the reader
+     * @return
+     */
+    private Translation buildTranslation(CursorReader reader) {
+        Language l = new Language(reader.getString("language_slug"), reader.getString("language_name"), reader.getString("direction"));
+
+        Project p = new Project(reader.getString("project_slug"), reader.getString("project_name"), reader.getInt("sort"));
+        p.description = reader.getString("desc");
+        p.icon = reader.getString("icon");
+        p.chunksUrl = reader.getString("chunks_url");
+        p.languageSlug = reader.getString("language_slug");
+
+        Resource r = new Resource(reader.getString("resource_slug"), reader.getString("resource_name"),
+                reader.getString("type"), reader.getString("translate_mode"), reader.getString("checking_level"), reader.getString("version"));
+        r.comments = reader.getString("comments");
+        r.pubDate = reader.getString("pub_date");
+        r.license = reader.getString("license");
+        r._legacyData.put(API.LEGACY_WORDS_ASSIGNMENTS_URL, reader.getString("translation_words_assignments_url"));
+
+        // load formats and add to resource
+        Cursor formatCursor = db.rawQuery("select * from resource_format where resource_id=" + reader.getLong("resource_id"), null);
+        formatCursor.moveToFirst();
+        while(!formatCursor.isAfterLast()) {
+            CursorReader formatReader = new CursorReader(formatCursor);
+
+            String packageVersion = formatReader.getString("package_version");
+            String mimeType = formatReader.getString("mime_type");
+            int modifiedAt = formatReader.getInt("modified_at");
+            String url = formatReader.getString("url");
+            boolean imported = formatReader.getBoolean("imported");
+
+            Resource.Format format = new Resource.Format(packageVersion, mimeType, modifiedAt, url, imported);
+            r.addFormat(format);
+            formatCursor.moveToNext();
+        }
+        formatCursor.close();
+        return new Translation(l, p, r);
+    }
+
+    public SourceLanguage getSourceLanguage(String sourceLanguageSlug) {
+        Cursor cursor = db.rawQuery("select * from source_language where slug=? limit 1", new String[]{sourceLanguageSlug});
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String name = reader.getString("name");
+            String direction = reader.getString("direction");
+
+            SourceLanguage sourceLanguage = new SourceLanguage(sourceLanguageSlug, name, direction);
+            cursor.close();
+            return sourceLanguage;
+        } else {
+            cursor.close();
+            return null;
+        }
+    }
+
+    public List<SourceLanguage> getSourceLanguages() {
+        Cursor cursor = db.rawQuery("select * from source_language order by slug asc", null);
+
+        List<SourceLanguage> sourceLanguages = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String direction = reader.getString("direction");
+
+            SourceLanguage sourceLanguage = new SourceLanguage(slug, name, direction);
+            sourceLanguages.add(sourceLanguage);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return sourceLanguages;
+    }
+
+    public List<SourceLanguage> getSourceLanguages(String projectSlug) {
+        Cursor cursor = db.rawQuery("select * from source_language where id in (" +
+                " select source_language_id from project" +
+                " where slug=?" +
+                " group by source_language_id" +
+                ") order by slug asc", new String[]{projectSlug});
+
+        List<SourceLanguage> sourceLanguages = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String direction = reader.getString("direction");
+
+            SourceLanguage sourceLanguage = new SourceLanguage(slug, name, direction);
+            sourceLanguages.add(sourceLanguage);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return sourceLanguages;
+    }
+
+    public TargetLanguage getTargetLanguage(String targetLangaugeSlug) {
+        TargetLanguage targetLanguage = null;
+        Cursor cursor = db.rawQuery("select * from (" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from target_language" +
+                "  union" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from temp_target_language" +
+                "  where approved_target_language_slug is null" +
+                ") where slug=? limit 1", new String[]{targetLangaugeSlug});
+
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String name = reader.getString("name");
+            String anglicized = reader.getString("anglicized_name");
+            String direction = reader.getString("direction");
+            String region = reader.getString("region");
+            boolean isGateWay = reader.getBoolean("is_gateway_language");
+
+            targetLanguage = new TargetLanguage(targetLangaugeSlug, name, anglicized, direction, region, isGateWay);
+        }
+        cursor.close();
+
+        return targetLanguage;
+    }
+
+    public List<TargetLanguage> findTargetLanguage(final String namequery) {
+        List<TargetLanguage> targetLanguages = new ArrayList<>();
+        Cursor cursor = db.rawQuery("select * from (" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from target_language" +
+                "  union" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from temp_target_language" +
+                "  where approved_target_language_slug is null" +
+                ") where lower(name) like ?" +
+                " order by slug asc, name asc", new String[]{"%" + namequery.toLowerCase() + "%"});
+
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String anglicized = reader.getString("anglicized_name");
+            String direction = reader.getString("direction");
+            String region = reader.getString("region");
+            boolean isGateWay = reader.getBoolean("is_gateway_language");
+
+            TargetLanguage targetLanguage = new TargetLanguage(slug, name, anglicized, direction, region, isGateWay);
+            targetLanguages.add(targetLanguage);
+            cursor.moveToNext();
+        }
+        cursor.close();
+
+        Collections.sort(targetLanguages, new Comparator<TargetLanguage>() {
+            @Override
+            public int compare(TargetLanguage lhs, TargetLanguage rhs) {
+                String lhId = lhs.slug;
+                String rhId = rhs.slug;
+                // give priority to matches with the id
+                if(lhId.toLowerCase().startsWith(namequery.toLowerCase())) {
+                    lhId = "!!" + lhId;
+                }
+                if(rhId.toLowerCase().startsWith(namequery.toLowerCase())) {
+                    rhId = "!!" + rhId;
+                }
+                if(lhs.name.toLowerCase().startsWith(namequery.toLowerCase())) {
+                    lhId = "!" + lhId;
+                }
+                if(rhs.name.toLowerCase().startsWith(namequery.toLowerCase())) {
+                    rhId = "!" + rhId;
+                }
+                return lhId.compareToIgnoreCase(rhId);
+            }
+        });
+
+        return targetLanguages;
+    }
+
+    public List<TargetLanguage> getTargetLanguages() {
+        Cursor cursor = db.rawQuery("select * from (" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from target_language" +
+                "  union" +
+                "  select slug, name, anglicized_name, direction, region, is_gateway_language from temp_target_language" +
+                "  where approved_target_language_slug is null" +
+                ") order by slug asc, name asc", null);
+
+        List<TargetLanguage> languages = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String angName = reader.getString("anglicized_name");
+            String dir = reader.getString("direction");
+            String region = reader.getString("region");
+            boolean isGate = reader.getBoolean("is_gateway_language");
+
+            TargetLanguage newLang = new TargetLanguage(slug, name, angName, dir, region, isGate);
+            languages.add(newLang);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return languages;
+    }
+
+    public TargetLanguage getApprovedTargetLanguage(String tempTargetLanguageSlug) {
+        TargetLanguage language = null;
+
+        Cursor cursor = db.rawQuery("select tl.* from target_language as tl" +
+                " left join temp_target_language as ttl on ttl.approved_target_language_slug=tl.slug" +
+                " where ttl.slug=?", new String[]{tempTargetLanguageSlug});
+
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String approvedSlug = reader.getString("slug");
+            String name = reader.getString("name");
+            String angName = reader.getString("anglicized_name");
+            String dir = reader.getString("direction");
+            String region = reader.getString("region");
+            boolean isGate = reader.getBoolean("is_gateway_language");
+
+            language = new TargetLanguage(approvedSlug, name, angName, dir, region, isGate);
+            cursor.close();
+        }
+        return language;
+    }
+
+    public Project getProject(String sourceLanguageSlug, String projectSlug) {
+        return getProject(sourceLanguageSlug, projectSlug, false);
+    }
+
+    public Project getProject(String sourceLanguageSlug, String projectSlug, boolean enableDefaultLanguage) {
+        Project project = null;
+        Cursor cursor = db.rawQuery("select p.*, sl.slug as source_language_slug from project as p" +
+                " left join source_language as sl on sl.id=p.source_language_id" +
+                " where p.slug=? and sl.slug LIKE (?)" +
+                " limit 1", new String[]{projectSlug, sourceLanguageSlug});
+
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String desc = reader.getString("desc");
+            String icon = reader.getString("icon");
+            int sort = reader.getInt("sort");
+            String chunksUrl = reader.getString("chunks_url");
+
+            project = new Project(slug, name, sort);
+            project.description = desc;
+            project.icon = icon;
+            project.chunksUrl = chunksUrl;
+            project.languageSlug = reader.getString("source_language_slug");
+        }
+        cursor.close();
+
+        // attempt to fetch the default language
+        if(project == null && enableDefaultLanguage) project = getProject("en", projectSlug, false);
+        if(project == null && enableDefaultLanguage) project = getProject("%", projectSlug, false);
+
+        return project;
+    }
+
+    public List<Project> getProjects(String sourceLanguageSlug) {
+        return getProjects(sourceLanguageSlug, false);
+    }
+
+    public List<Project> getProjects(String sourceLanguageSlug, boolean enableDefaultLanguage) {
+        List<Project> projects = new ArrayList<>();
+        Cursor cursor;
+        if(enableDefaultLanguage) {
+            // TRICKY: this should work on android but is not working on the tests
+            cursor = db.rawQuery("select p.*, sl.slug as source_language_slug," +
+                " max(case sl.slug when ? then 3 when ? then 2 else 1 end) as weight" +
+                " from project as p" +
+                " left join source_language as sl on sl.id=p.source_language_id" +
+                " group by p.slug" +
+                " order by p.sort asc", new String[]{sourceLanguageSlug, "en"});
+
+            // another alternative that "should" work
+//            cursor = db.rawQuery("select p.*, sl.slug as source_language_slug, max(weight) from (" +
+//                    "  select *, 3 as weight from project where source_language_id in (" +
+//                    "    select id from source_language where slug=?" +
+//                    "  )" +
+//                    "  union" +
+//                    "  select *, 2 as weight from project where source_language_id in (" +
+//                    "    select id from source_language where slug=?" +
+//                    "  )" +
+//                    "  union" +
+//                    "  select *, 1 as weight from project" +
+//                    " ) as p" +
+//                    " left join source_language as sl on sl.id=p.source_language_id" +
+//                    " group by p.slug" +
+//                    " order by p.sort asc", new String[]{sourceLanguageSlug, "en"});
+
+            // another alternative that "should" work
+//            cursor = db.rawQuery("select p.*, sl.slug as source_language_slug from project as p" +
+//                    " left join source_language as sl on sl.id=p.source_language_id" +
+//                    " where p.id in (" +
+//                    "   select id from (" +
+//                    "     select max(weight), id from (" +
+//                    "       select *, 3 as weight from project where source_language_id in (" +
+//                    "         select id from source_language where slug=?" +
+//                    "       )" +
+//                    "       union" +
+//                    "       select *, 2 as weight from project where source_language_id in (" +
+//                    "         select id from source_language where slug=?" +
+//                    "       )" +
+//                    "       union" +
+//                    "       select *, 1 as weight from project" +
+//                    "     )" +
+//                    "     group by slug" +
+//                    "   )" +
+//                    " )" +
+//                    " order by p.sort asc", new String[]{sourceLanguageSlug, "en"});
+        } else {
+            cursor = db.rawQuery("select * from project" +
+                    " where source_language_id in (select id from source_language where slug=?)" +
+                    " order by sort asc", new String[]{sourceLanguageSlug});
+        }
+
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            int sort = reader.getInt("sort");
+
+            Project project = new Project(slug, name, sort);
+            project.description = reader.getString("desc");
+            project.icon = reader.getString("icon");
+            project.chunksUrl = reader.getString("chunks_url");
+            if(enableDefaultLanguage) {
+                project.languageSlug = reader.getString("source_language_slug");
+            } else {
+                project.languageSlug = sourceLanguageSlug;
+            }
+
+            projects.add(project);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return projects;
+    }
+
+    // TODO: 9/28/16 or findProjectSourceLanguages(String projectSlug) so we can find languages that have this project
+    // TODO: 9/28/16 potentially add getTranslationProgress
+    // TODO: 9/28/16 allow filtering by checking level (resource containers, projects, resources).. maybe we could do with just resource containers.
+
+    // we can use this in place of
+    public List<CategoryEntry> getProjectCategories(long parentCategoryId, String languageSlug, String translateMode) {
+        Cursor categoryCursor;
+        String[] preferredSlug = {languageSlug, "en", "%"};
+        List<CategoryEntry> projectCategories = new ArrayList<>();
+        if(translateMode == null) translateMode = "";
+
+        // load categories
+        if(!translateMode.isEmpty()) {
+            categoryCursor = db.rawQuery("select \'category\' as type, c.slug as name, \'\' as source_language_slug," +
+                    " c.id, c.slug, c.parent_id, count(p.id) as num, max(p.sort) as csort from category as c" +
+                    " left join (" +
+                    "  select p.id, p.category_id, p.sort, count(r.id) as num from project as p" +
+                    "  left join (" +
+                    "   select r.*, count(rf.id) as num_imported from resource as r" +
+                    "   left join resource_format as rf on rf.resource_id=r.id and rf.imported='1'" +
+                    "   group by r.id" +
+                    "  ) as r on r.project_id=p.id and (r.translate_mode like (?) or r.num_imported > 0)" +
+                    "  group by p.slug" +
+                    " ) p on p.category_id=c.id and p.num > 0" +
+                    " where parent_id=" + parentCategoryId + " and num > 0 " +
+                    " group by c.slug" +
+                    " order by csort", new String[]{translateMode});
+        } else {
+            // TODO: left join projects were so we can max the sort so we can order the categories.
+            categoryCursor = db.rawQuery("select \'category\' as type, category.slug as name, \'\'" +
+                    " as source_language_slug, *" +
+                    " from category" +
+                    " where parent_id=" + parentCategoryId +
+                    " group by category.slug", null);
+        }
+
+        //find best name
+        categoryCursor.moveToFirst();
+        while(!categoryCursor.isAfterLast()) {
+            String catSlug = categoryCursor.getString(categoryCursor.getColumnIndex("slug"));
+            int catId = categoryCursor.getInt(categoryCursor.getColumnIndex("id"));
+
+            for(String slug : preferredSlug) {
+                Cursor cursor = db.rawQuery("select sl.slug as source_language_slug, cn.name as name" +
+                        " from category_name as cn" +
+                        " left join source_language as sl on sl.id=cn.source_language_id" +
+                        " where sl.slug like(?) and cn.category_id=" + catId, new String[]{slug});
+
+                if(cursor.moveToFirst()) {
+                    CursorReader reader = new CursorReader(cursor);
+
+                    String catName = reader.getString("name");
+                    String catSourceLanguageSlug = reader.getString("source_language_slug");
+
+                    CategoryEntry categoryEntry = new CategoryEntry(CategoryEntry.Type.CATEGORY, catId, catSlug, catName, catSourceLanguageSlug, parentCategoryId);
+                    projectCategories.add(categoryEntry);
+                    cursor.close();
+                    break;
+                }
+                cursor.close();
+            }
+            categoryCursor.moveToNext();
+        }
+        categoryCursor.close();
+
+        // load projects
+        Cursor projectCursor = db.rawQuery("select * from (" +
+                " select \'project\' as type, \'\' as source_language_slug," +
+                " p.id, p.slug, p.sort, p.name, count(r.id) as num from project as p" +
+                " left join (" +
+                "  select r.*, count(rf.id) as num_imported from resource as r" +
+                "  left join resource_format as rf on rf.resource_id=r.id and rf.imported='1'" +
+                "  group by r.id" +
+                " ) as r on r.project_id=p.id and (r.translate_mode like (?) or r.num_imported > 0)" +
+                " where p.category_id=" + parentCategoryId + " group by p.slug" +
+                " order by p.sort asc)" + (!translateMode.isEmpty() ? " where num > 0" : ""),
+                new String[]{(!translateMode.isEmpty() ? translateMode : "%")});
+
+        //find best name
+        projectCursor.moveToFirst();
+        while(!projectCursor.isAfterLast()) {
+            String projectSlug = projectCursor.getString(projectCursor.getColumnIndex("slug"));
+            long projectId = projectCursor.getLong(projectCursor.getColumnIndex("id"));
+            for(String slug : preferredSlug) {
+                Cursor cursor = db.rawQuery("select sl.slug as source_language_slug, p.name as name" +
+                        " from project as p" +
+                        " left join source_language as sl on sl.id=p.source_language_id" +
+                        " where sl.slug like(?) and p.slug=? order by sl.slug asc", new String[]{slug, projectSlug});
+                if(cursor.moveToFirst()) {
+                    CursorReader reader = new CursorReader(cursor);
+
+                    String projectName = reader.getString("name");
+                    String projSourceLangSlug = reader.getString("source_language_slug");
+
+                    CategoryEntry categoryEntry = new CategoryEntry(CategoryEntry.Type.PROJECT, projectId, projectSlug, projectName, projSourceLangSlug, parentCategoryId);
+                    projectCategories.add(categoryEntry);
+                    cursor.close();
+                    break;
+                }
+                cursor.close();
+            }
+            projectCursor.moveToNext();
+        }
+        projectCursor.close();
+
+        return projectCategories;
+    }
+
+    @Nullable
+    public Resource getResource(String sourceLanguageSlug, String projectSlug, String resourceSlug) {
+        Resource resource = null;
+        Cursor cursor = db.rawQuery("select r.id, r.name, r.translate_mode, r.type, r.checking_level," +
+                " r.comments, r.pub_date, r.license, r.version," +
+                " lri.translation_words_assignments_url from resource as r" +
+                " left join legacy_resource_info as lri on lri.resource_id=r.id" +
+                " where r.slug=? and r.project_id in (" +
+                "  select id from project where slug=? and source_language_id in (" +
+                "  select id from source_language where slug=?)" +
+                " ) limit 1", new String[]{resourceSlug, projectSlug, sourceLanguageSlug});
+
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            long resourceId = reader.getLong("id");
+            String name = reader.getString("name");
+            String translateMode = reader.getString("translate_mode");
+            String type = reader.getString("type");
+            String checkingLevel = reader.getString("checking_level");
+            String comments = reader.getString("comments");
+            String pubDate = reader.getString("pub_date");
+            String license = reader.getString("license");
+            String version = reader.getString("version");
+            String wordsAssignmentsUrl = reader.getString("translation_words_assignments_url");
+
+            resource = new Resource(resourceSlug, name, type, translateMode, checkingLevel, version);
+            resource._legacyData.put(API.LEGACY_WORDS_ASSIGNMENTS_URL, wordsAssignmentsUrl);
+            resource.comments = comments;
+            resource.pubDate = pubDate;
+            resource.license = license;
+
+            // load formats and add to resource
+            Cursor formatCursor = db.rawQuery("select * from resource_format where resource_id=" + resourceId, null);
+            formatCursor.moveToFirst();
+            while(!formatCursor.isAfterLast()) {
+                CursorReader formatReader = new CursorReader(formatCursor);
+
+                String packageVersion = formatReader.getString("package_version");
+                String mimeType = formatReader.getString("mime_type");
+                int modifiedAt = formatReader.getInt("modified_at");
+                String url = formatReader.getString("url");
+                boolean imported = formatReader.getBoolean("imported");
+
+                Resource.Format format = new Resource.Format(packageVersion, mimeType, modifiedAt, url, imported);
+                resource.addFormat(format);
+                formatCursor.moveToNext();
+            }
+            formatCursor.close();
+        }
+        cursor.close();
+        return resource;
+    }
+
+    public List<Resource> getResources(String languageSlug, String projectSlug) {
+        List<Resource> resources = new ArrayList<>();
+        Cursor resourceCursor = null;
+        if(languageSlug != null && !languageSlug.isEmpty()) {
+            resourceCursor = db.rawQuery("select r.*, lri.translation_words_assignments_url from resource as r" +
+                    " left join legacy_resource_info as lri on lri.resource_id=r.id" +
+                    " where r.project_id in (" +
+                    "  select id from project where slug=? and source_language_id in (" +
+                    "   select id from source_language where slug=?)" +
+                    " )" +
+                    " order by r.slug asc", new String[]{projectSlug, languageSlug});
+        } else {
+            resourceCursor = db.rawQuery("select sl.slug as source_language_slug, r.*, lri.translation_words_assignments_url from resource as r" +
+                    " left join legacy_resource_info as lri on lri.resource_id=r.id" +
+                    " left join project as p on p.id=r.project_id" +
+                    " left join (" +
+                    "  select id, slug from source_language" +
+                    " ) as sl on sl.id=p.source_language_id" +
+                    " where p.slug=? order by r.slug asc", new String[]{projectSlug});
+        }
+
+        resourceCursor.moveToFirst();
+        while(!resourceCursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(resourceCursor);
+
+            long resourceId = reader.getLong("id");
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+            String translateMode = reader.getString("translate_mode");
+            String type = reader.getString("type");
+            String checkingLevel = reader.getString("checking_level");
+            String comments = reader.getString("comments");
+            String pubDate = reader.getString("pub_date");
+            String license = reader.getString("license");
+            String version = reader.getString("version");
+            String wordsAssignmentsUrl = reader.getString("translation_words_assignments_url");
+
+            HashMap status = new HashMap();
+            status.put("translateMode", translateMode);
+            status.put("checkingLevel", checkingLevel);
+            status.put("comments", comments);
+            status.put("pub_date", pubDate);
+            status.put("license", license);
+            status.put("version", version);
+
+            Resource resource = new Resource(slug, name, type, translateMode, checkingLevel, version);
+            resource._legacyData.put(API.LEGACY_WORDS_ASSIGNMENTS_URL, wordsAssignmentsUrl);
+            resource.comments = comments;
+            resource.pubDate = pubDate;
+            resource.license = license;
+
+            // load formats and add to resource
+            Cursor formatCursor = db.rawQuery("select * from resource_format where resource_id=" + resourceId, null);
+            formatCursor.moveToFirst();
+            while(!formatCursor.isAfterLast()) {
+                CursorReader formatReader = new CursorReader(formatCursor);
+
+                String packageVersion = formatReader.getString("package_version");
+                String mimeType = formatReader.getString("mime_type");
+                int modifiedAt = formatReader.getInt("modified_at");
+                String url = formatReader.getString("url");
+                boolean imported = formatReader.getBoolean("imported");
+
+                Resource.Format format = new Resource.Format(packageVersion, mimeType, modifiedAt, url, imported);
+                resource.addFormat(format);
+                formatCursor.moveToNext();
+            }
+            formatCursor.close();
+
+            resources.add(resource);
+            resourceCursor.moveToNext();
+        }
+        resourceCursor.close();
+        return resources;
+    }
+
+    public Catalog getCatalog(String catalogSlug) {
+        Catalog catalog = null;
+        Cursor cursor = db.rawQuery("select id, url, modified_at from catalog where slug=?", new String[]{catalogSlug});
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String url = reader.getString("url");
+            int modifiedAt = reader.getInt("modified_at");
+
+            catalog = new Catalog(catalogSlug, url, modifiedAt);
+        }
+        cursor.close();
+        return catalog;
+    }
+
+    public List<Catalog> getCatalogs() {
+        Cursor cursor = db.rawQuery("select * from catalog", null);
+
+        List<Catalog> catalogs = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String url = reader.getString("url");
+            int modifiedAt = reader.getInt("modified_at");
+
+            Catalog catalog = new Catalog(slug, url, modifiedAt);
+            catalogs.add(catalog);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return catalogs;
+    }
+
+    public Versification getVersification(String sourceLanguageSlug, String versificationSlug) {
+        Versification versification = null;
+        Cursor cursor = db.rawQuery("select v.id, v.slug, vn.name from versification_name as vn" +
+                " left join versification as v on v.id=vn.versification_id" +
+                " left join source_language as sl on sl.id=vn.source_language_id" +
+                " where sl.slug=? and v.slug=?", new String[]{sourceLanguageSlug, versificationSlug});
+
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+
+            versification = new Versification(slug, name);
+            versification.rowId = reader.getLong("id");
+        }
+        cursor.close();
+        return versification;
+    }
+
+    public List<Versification> getVersifications(String sourceLanguageSlug) {
+        Cursor cursor = db.rawQuery("select vn.name, v.slug, v.id from versification_name as vn" +
+                " left join versification as v on v.id=vn.versification_id" +
+                " left join source_language as sl on sl.id=vn.source_language_id" +
+                " where sl.slug=?", new String[]{sourceLanguageSlug});
+
+        List<Versification> versifications = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String slug = reader.getString("slug");
+            String name = reader.getString("name");
+
+            Versification versification = new Versification(slug, name);
+            versification.rowId = reader.getLong("id");
+            versifications.add(versification);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return versifications;
+    }
+
+    public List<ChunkMarker> getChunkMarkers(String projectSlug, String versificationSlug) {
+        Cursor cursor = db.rawQuery("select cm.id, cm.chapter, cm.verse from chunk_marker as cm" +
+                " left join versification as v on v.id=cm.versification_id" +
+                " where v.slug=? and cm.project_slug=?", new String[]{versificationSlug, projectSlug});
+
+        List<ChunkMarker> chunkMarkers = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String chapter = reader.getString("chapter");
+            String verse = reader.getString("verse");
+
+            ChunkMarker chunkMarker = new ChunkMarker(chapter, verse);
+            chunkMarkers.add(chunkMarker);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return chunkMarkers;
+    }
+
+    public Questionnaire getQuestionnaire(long tdId) {
+        Questionnaire questionnaire = null;
+        Cursor cursor = db.rawQuery("select * from questionnaire" +
+                " where td_id=" + tdId, null);
+        cursor.moveToFirst();
+        if(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            // load data fields
+            Cursor dataFieldsCursor = db.rawQuery("select field, question_td_id from questionnaire_data_field" +
+                    " where questionnaire_id=" + reader.getLong("id"), null);
+            Map<String, Long> dataFields = new HashMap<>();
+            dataFieldsCursor.moveToFirst();
+            while(!dataFieldsCursor.isAfterLast()) {
+                CursorReader dataFieldReader = new CursorReader(dataFieldsCursor);
+                dataFields.put(dataFieldReader.getString("field"), dataFieldReader.getLong("question_td_id"));
+                dataFieldsCursor.moveToNext();
+            }
+            dataFieldsCursor.close();;
+
+            questionnaire = new Questionnaire(reader.getString("language_slug"),
+                    reader.getString("language_name"),
+                    reader.getString("language_direction"),
+                    reader.getLong("td_id"),
+                    dataFields);
+        }
+        cursor.close();
+        return questionnaire;
+    }
+
+    public List<Questionnaire> getQuestionnaires() {
+        Cursor cursor = db.rawQuery("select * from questionnaire", null);
+
+        List<Questionnaire> questionnaires = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            long id = reader.getLong("id");
+            String slug = reader.getString("language_slug");
+            String name = reader.getString("language_name");
+            String direction = reader.getString("language_direction");
+            long tdId = reader.getLong("td_id");
+
+            // load data fields
+            Cursor dataFieldsCursor = db.rawQuery("select field, question_td_id from questionnaire_data_field" +
+                    " where questionnaire_id=" + id, null);
+            Map<String, Long> dataFields = new HashMap<>();
+            dataFieldsCursor.moveToFirst();
+            while(!dataFieldsCursor.isAfterLast()) {
+                CursorReader dataFieldReader = new CursorReader(dataFieldsCursor);
+                dataFields.put(dataFieldReader.getString("field"), dataFieldReader.getLong("question_td_id"));
+                dataFieldsCursor.moveToNext();
+            }
+            dataFieldsCursor.close();;
+
+            Questionnaire questionnaire = new Questionnaire(slug, name, direction, tdId, dataFields);
+            questionnaires.add(questionnaire);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return questionnaires;
+    }
+
+    public List<Question> getQuestions(long questionnaireTDId) {
+        Cursor cursor = db.rawQuery("select * from question where questionnaire_id in (" +
+                " select id from questionnaire where td_id=" + questionnaireTDId + ")" +
+                " order by sort asc", null);
+
+        List<Question> questions = new ArrayList<>();
+        cursor.moveToFirst();
+        while(!cursor.isAfterLast()) {
+            CursorReader reader = new CursorReader(cursor);
+
+            String text = reader.getString("text");
+            String help = reader.getString("help");
+            boolean isRequired = reader.getBoolean("is_required");
+            String inputType = reader.getString("input_type");
+            int sort = reader.getInt("sort");
+            long dependsOn = reader.getInt("depends_on");
+            long tdId = reader.getInt("td_id");
+
+            Question question = new Question(text, help, isRequired, Question.InputType.get(inputType), sort, dependsOn, tdId);
+            questions.add(question);
+            cursor.moveToNext();
+        }
+        cursor.close();
+        return questions;
+    }
+
+    public Category getCategory(String languageSlug, String slug) {
+        Cursor cursor = db.rawQuery("select cn.name, c.slug from category as c" +
+                " left join category_name as cn on cn.category_id=c.id" +
+                " left join source_language as sl on sl.id=cn.source_language_id" +
+                " where c.slug=? and sl.slug=?", new String[]{slug, languageSlug});
+        Category cat = null;
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+            cat = new Category(reader.getString("slug"), reader.getString("name"));
+        }
+        cursor.close();
+        return cat;
+    }
+
+    /**
+     * Returns the parent category of the given category
+     * @param languageSlug the language of the parent category name
+     * @param childCategorySlug the slug of the child category
+     * @return the parent category of null if there is no parent
+     */
+    private Category getParentCategory(String languageSlug, String childCategorySlug) {
+        Cursor cursor = db.rawQuery("select pcn.name, pc.slug from category as pc" +
+                " left join category as cc on cc.parent_id=pc.id" +
+                " left join category_name as pcn on pcn.category_id=pc.id" +
+                " left join source_language as sl on sl.id=pcn.source_language_id" +
+                " where cc.slug=? and sl.slug=?", new String[]{childCategorySlug, languageSlug});
+        Category cat = null;
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+            cat = new Category(reader.getString("slug"), reader.getString("name"));
+        }
+        cursor.close();
+        return cat;
+    }
+
+    public List<Category> getCategories(String languageSlug, String projectSlug) {
+        List<Category> categories = new ArrayList<>();
+        Cursor cursor = db.rawQuery("select c.slug, cn.name from category as c" +
+                " left join category_name as cn on cn.category_id=c.id" +
+                " left join source_language as sl on sl.id=cn.source_language_id" +
+                " left join project as p on p.source_language_id=sl.id and p.category_id=c.id" +
+                " where p.slug=? and sl.slug=?", new String[]{projectSlug, languageSlug});
+        if(cursor.moveToFirst()) {
+            CursorReader reader = new CursorReader(cursor);
+            Category cat = new Category(reader.getString("slug"), reader.getString("name"));
+            categories.add(cat);
+            cursor.close();
+
+            // find the rest of the categories
+            String previousSlug = cat.slug;
+            Category nextCat = null;
+            do {
+                nextCat = getParentCategory(languageSlug, previousSlug);
+                if(nextCat != null) {
+                    previousSlug = nextCat.slug;
+                    categories.add(0, nextCat);
+                }
+            } while (nextCat != null);
+        } else {
+            cursor.close();
+        }
+
+        return categories;
+    }
+
+    /**
+     * Removes all target language data
+     */
+    public void clearTargetLanguages() {
+        truncateTable("target_language");
+        vacuum();
+    }
+
+    /**
+     * Removes all the temp target language data
+     */
+    public void clearTempLanguages() {
+        truncateTable("temp_target_language");
+        vacuum();
+    }
+
+    /**
+     * Removes all questionnaire data
+     */
+    public void clearNewLanguageQuestions() {
+        truncateTable("questionnaire_data_field");
+        truncateTable("question");
+        truncateTable("questionnaire");
+        vacuum();
+    }
+
+    /**
+     * Clears out all assigned target languages.
+     * This does not actually truncate anything just sets all the approved slugs to null.
+     */
+    public void clearApprovedTempLanguages() {
+        db.rawQuery("update temp_target_language set approved_target_language_slug=null", null);
+    }
+
+    /**
+     * A tool to remove all data from a table.
+     * Use this with caution.
+     * @param table the table that will lose all it's data.
+     */
+    protected void truncateTable(String table) {
+        db.rawQuery("delete from ".concat(table), null);
+    }
+
+    /**
+     * Cleans the database.
+     * This eliminates free pages, aligns table data to be contiguous,
+     * and otherwise cleans up the database file structure.
+     */
+    protected void vacuum() {
+        try {
+            db.rawQuery("vacuum", null);
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+    }
+
+    /**
+     * Represents the result from and insertOrIgnore or insertOrUpdate
+     */
+    private static class InsertResult {
+        public final boolean inserted;
+        public final long id;
+
+        /**
+         *
+         * @param id the id of the record
+         * @param inserted set to true if the record was a new insert and false if it is an existing one
+         */
+        public InsertResult(long id, boolean inserted) {
+            this.id = id;
+            this.inserted = inserted;
+        }
+    }
+
+    /**
+     * A helper class to make reading from a cursor easier.
+     */
+    private static class CursorReader {
+        private final Cursor cursor;
+
+        public CursorReader(Cursor cursor) {
+            this.cursor =cursor;
+        }
+
+        public String getString(String key)  {
+            return this.cursor.getString(this.cursor.getColumnIndexOrThrow(key));
+        }
+
+        public long getLong(String key) {
+            return this.cursor.getLong(this.cursor.getColumnIndexOrThrow(key));
+        }
+
+        public int getInt(String key) {
+            return this.cursor.getInt(this.cursor.getColumnIndexOrThrow(key));
+        }
+
+        public boolean getBoolean(String key) {
+            return this.cursor.getInt(this.cursor.getColumnIndexOrThrow(key)) > 0;
+        }
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/Library.java
+++ b/app/src/main/java/org/unfoldingword/door43client/Library.java
@@ -1557,7 +1557,7 @@ class Library implements Index {
      * @param table the table that will lose all it's data.
      */
     protected void truncateTable(String table) {
-        db.rawQuery("delete from ".concat(table), null);
+        db.rawQuery("delete from ".concat(table), null).moveToNext();
     }
 
     /**

--- a/app/src/main/java/org/unfoldingword/door43client/OnLogListener.java
+++ b/app/src/main/java/org/unfoldingword/door43client/OnLogListener.java
@@ -1,0 +1,10 @@
+package org.unfoldingword.door43client;
+
+/**
+ * A utility to receive log events from the module
+ */
+public interface OnLogListener {
+    void onInfo(String message);
+    void onWarning(String message);
+    void onError(String message, Exception ex);
+}

--- a/app/src/main/java/org/unfoldingword/door43client/OnProgressListener.java
+++ b/app/src/main/java/org/unfoldingword/door43client/OnProgressListener.java
@@ -1,0 +1,15 @@
+package org.unfoldingword.door43client;
+
+/**
+ * A utility to get progress updates during long operations
+ */
+public interface OnProgressListener {
+    /**
+     *
+     * @param tag used to identify what progress event is occurring
+     * @param max the total number of items being processed
+     * @param complete the number of items that have been successfully processed
+     * @return cancels the operation if false is returned
+     */
+    boolean onProgress(String tag, long max, long complete);
+}

--- a/app/src/main/java/org/unfoldingword/door43client/SQLiteHelper.java
+++ b/app/src/main/java/org/unfoldingword/door43client/SQLiteHelper.java
@@ -1,0 +1,80 @@
+package org.unfoldingword.door43client;
+
+import android.content.Context;
+import android.database.sqlite.SQLiteDatabase;
+import android.database.sqlite.SQLiteOpenHelper;
+import android.os.Build;
+
+import java.io.File;
+
+/**
+ * A SQLite database helper
+ */
+class SQLiteHelper extends SQLiteOpenHelper {
+    public static final int DATABASE_VERSION = 1;
+    private final String schema;
+
+    /**
+     *
+     * @param context
+     * @param schema The sqlite schema
+     * @param name the db name
+     */
+    public SQLiteHelper(Context context, String schema, String name) {
+        super(context, name, null, DATABASE_VERSION);
+        this.schema = schema;
+    }
+
+    @Override
+    public void onCreate(SQLiteDatabase db) {
+        if(Build.VERSION.SDK_INT < Build.VERSION_CODES.JELLY_BEAN) {
+            db.execSQL("PRAGMA foreign_keys=OFF;");
+        } else {
+            db.setForeignKeyConstraintsEnabled(false);
+        }
+        String[] queries = schema.split(";");
+        for (String query : queries) {
+            query = query.trim();
+            if(!query.isEmpty()) {
+                try {
+                    db.execSQL(query);
+                } catch (Exception e) {
+                    e.printStackTrace();
+                }
+            }
+        }
+    }
+
+    /**
+     * TRICKY: this is only supported in API 16+
+     * @param db
+     */
+    @Override
+    public void onConfigure(SQLiteDatabase db) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            db.setForeignKeyConstraintsEnabled(false);
+        } else {
+            db.execSQL("PRAGMA foreign_keys=OFF;");
+        }
+    }
+
+    @Override
+    public void onUpgrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        // TRICKY: if this is used to manage upgrades care must be taken to ensure the correct DATABASE_VERSION
+        // is set in the db that is packaged with an android app. Otherwise the packaged db may get overwritten.
+    }
+
+    @Override
+    public void onDowngrade(SQLiteDatabase db, int oldVersion, int newVersion) {
+        onCreate(db);
+    }
+
+    @Override
+    public void onOpen(SQLiteDatabase db) {
+        if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.JELLY_BEAN) {
+            db.setForeignKeyConstraintsEnabled(true);
+        } else {
+            db.execSQL("PRAGMA foreign_keys=ON;");
+        }
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/WhereClause.java
+++ b/app/src/main/java/org/unfoldingword/door43client/WhereClause.java
@@ -1,0 +1,66 @@
+package org.unfoldingword.door43client;
+
+import android.content.ContentValues;
+import android.text.TextUtils;
+
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * This is a utility class for preparing a where clause
+ */
+class WhereClause {
+    public final String statement;
+    public final String[] arguments;
+
+    private WhereClause(String statement, String[] values) {
+        this.statement = statement;
+        this.arguments = values;
+    }
+
+    /**
+     * Performs a bunch of magical operations to convert a set of values and the specified unique columns
+     * into a valid where clause with supporting values.
+     *
+     *
+     *
+     * @param values
+     * @param uniqueColumns
+     * @return
+     */
+    public static WhereClause prepare(ContentValues values, String[] uniqueColumns) {
+        List<String> stringColumns = new ArrayList<>();
+        List<String> numberColumns = new ArrayList<>();
+
+        // split columns into sets by type
+        for(String key:uniqueColumns) {
+            if(values.get(key) instanceof String) {
+                stringColumns.add(key);
+            } else {
+                numberColumns.add(key);
+            }
+        }
+
+        // build the statement
+        String whereStmt = "";
+        if(stringColumns.size() > 0) {
+            whereStmt = TextUtils.join("=? and ", stringColumns) + "=?";
+        }
+        if(numberColumns.size() > 0) {
+            if (!whereStmt.isEmpty()) whereStmt += " and ";
+            List<String> expressions = new ArrayList<>();
+            for(String key:numberColumns) {
+                expressions.add(key + "=" + values.get(key));
+            }
+            whereStmt += TextUtils.join(" and ", expressions);
+        }
+
+        // build the values
+        String[] uniqueValues = new String[stringColumns.size()];
+        for(int i = 0; i < stringColumns.size(); i ++) {
+            uniqueValues[i] = String.valueOf(values.get(stringColumns.get(i)));
+        }
+
+        return new WhereClause(whereStmt, uniqueValues);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Catalog.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Catalog.java
@@ -1,0 +1,23 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents a global catalog
+ */
+public class Catalog {
+    public final String slug;
+    public final String url;
+    public final int modifiedAt;
+
+    /**
+     *
+     * @param slug the catalog code
+     * @param url the url where the catalog exists
+     * @param modifiedAt when the catalog was last modified
+     */
+    public Catalog(String slug, String url, int modifiedAt) {
+        this.slug = slug;
+        this.url = url;
+        this.modifiedAt = modifiedAt;
+    }
+
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Category.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Category.java
@@ -1,0 +1,20 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents a project category. e.g. a group of projects.
+ */
+public class Category {
+    public final String slug;
+    public final String name;
+
+    /**
+     *
+     * @param slug the category code
+     * @param name the name of the category
+     */
+    public Category(String slug, String name) {
+        this.name = name;
+        this.slug = slug;
+    }
+
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/CategoryEntry.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/CategoryEntry.java
@@ -1,0 +1,39 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents a single entry in the list of project/categories
+ * i.e. when you are choosing project to translate.
+ */
+public class CategoryEntry {
+
+    public final Type entryType;
+    public final long id;
+    public final String slug;
+    public final String name;
+    public final String sourceLanguageSlug;
+    public final long parentCategoryId;
+
+    /**
+     *
+     * @param entryType the type of entry this is e.g. a project or category
+     * @param id the db id of the project/category
+     * @param slug the slug of the project/category
+     * @param name the human readable name of the project/category
+     * @param sourceLanguageSlug the slug of the source language in which the name is given (e.g. the name is translated in German, or French)
+     * @param parentCategoryId the db id of the parent category id (only used when the entry type is category
+     */
+    public CategoryEntry(Type entryType, long id, String slug, String name, String sourceLanguageSlug, long parentCategoryId) {
+
+        this.entryType = entryType;
+        this.id = id;
+        this.slug = slug;
+        this.name = name;
+        this.sourceLanguageSlug = sourceLanguageSlug;
+        this.parentCategoryId = parentCategoryId;
+    }
+
+    public enum Type {
+        PROJECT,
+        CATEGORY
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/ChunkMarker.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/ChunkMarker.java
@@ -1,0 +1,20 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents the beginning of a chunk in a chapter
+ */
+public class ChunkMarker {
+    public final String chapter;
+    public final String verse;
+
+    /**
+     *
+     * @param chapter the chapter this chunk exists in
+     * @param verse the verse at which this chunk starts
+     */
+    public ChunkMarker(String chapter, String verse) {
+        this.chapter = chapter;
+        this.verse = verse;
+    }
+
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Question.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Question.java
@@ -1,0 +1,77 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents a single question in a questionnaire
+ */
+public class Question {
+    public final String text;
+    public final String help;
+    public final boolean isRequired;
+    public final InputType inputType;
+    public final int sort;
+    /**
+     * The question this one depends on. If -1 there is no dependency
+     */
+    public final long dependsOn;
+    /**
+     * This question's translation database id
+     */
+    public final long tdId;
+
+    /**
+     *
+     * @param text the question
+     * @param help optional help text
+     * @param isRequired indicates if this question requires an answer
+     * @param inputType the type of form input used to display this question e.g. input text, boolean
+     * @param sort the sorting order of this question
+     * @param dependsOn the translation database id of the question that this question depends on. Set as -1 for no dependency
+     * @param tdId the translation database id of this question (server side)
+     */
+    public Question(String text, String help, boolean isRequired, InputType inputType, int sort, long dependsOn, long tdId) {
+        this.text = text;
+        this.help = help;
+        this.isRequired = isRequired;
+        this.inputType = inputType;
+        this.sort = sort;
+        this.dependsOn = dependsOn;
+        this.tdId = tdId;
+    }
+
+    public enum InputType {
+        String("string"),
+        Boolean("boolean"),
+        Date("date");
+
+        InputType(String label) {
+            this.label = label;
+        }
+
+        private final String label;
+
+        public String getLabel() {
+            return label;
+        }
+
+        @Override
+        public String toString() {
+            return getLabel();
+        }
+
+        /**
+         * Returns an input type by it's label
+         * @param label
+         * @return
+         */
+        public static InputType get(String label) {
+            if(label != null) {
+                for (InputType t : InputType.values()) {
+                    if (t.getLabel().equals(label.toLowerCase())) {
+                        return t;
+                    }
+                }
+            }
+            return null;
+        }
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Questionnaire.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Questionnaire.java
@@ -1,0 +1,32 @@
+package org.unfoldingword.door43client.models;
+
+import java.util.HashMap;
+import java.util.Map;
+
+/**
+ * Represents a questionnaire that can be completed in the app
+ */
+public class Questionnaire {
+    public final String languageSlug;
+    public final String languageName;
+    public final String languageDirection;
+    public final long tdId;
+    public final Map<String, Long> dataFields;
+
+    /**
+     *
+     * @param languageSlug the language code
+     * @param languageName the name of the language in which this questionnaire is presented
+     * @param languageDirection the written direction of the language
+     * @param tdId the translation database id (server side)
+     * @param dataFields a map of question ids that represent certain language data. e.g. language name, region etc.
+     */
+    public Questionnaire(String languageSlug, String languageName, String languageDirection, long tdId, Map<String, Long> dataFields) {
+        this.languageSlug = languageSlug;
+        this.languageName = languageName;
+        this.languageDirection = languageDirection;
+        this.tdId = tdId;
+        this.dataFields = dataFields;
+    }
+
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/SourceLanguage.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/SourceLanguage.java
@@ -1,0 +1,40 @@
+package org.unfoldingword.door43client.models;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unfoldingword.resourcecontainer.Language;
+
+/**
+ * Represents a language that a resource exists in  (for the purpose of source content)
+ */
+public class SourceLanguage extends Language {
+
+    /**
+     * Creates a new source language
+     * @param slug the language code
+     * @param name the name of the language
+     * @param direction the written direction of the language
+     */
+    public SourceLanguage(String slug, String name, String direction) {
+        super(slug, name, direction);
+    }
+
+    /**
+     * Creates a new source language from a language
+     * @param language the language
+     */
+    public SourceLanguage(Language language) {
+        super(language.slug, language.name, language.direction);
+    }
+
+    /**
+     * Creates a source language from json
+     * @param json the language json
+     * @return the new source language
+     * @throws JSONException
+     */
+    public static SourceLanguage fromJSON(JSONObject json) throws JSONException {
+        Language l = Language.fromJSON(json);
+        return new SourceLanguage(l.slug, l.name, l.direction);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/TargetLanguage.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/TargetLanguage.java
@@ -1,0 +1,57 @@
+package org.unfoldingword.door43client.models;
+
+import org.json.JSONException;
+import org.json.JSONObject;
+import org.unfoldingword.resourcecontainer.Language;
+
+/**
+ * Represents a language that a resource will be translated into
+ */
+public class TargetLanguage extends Language {
+    public final String anglicizedName;
+    public final String region;
+    public final boolean isGatewayLanguage;
+
+    /**
+     * Creates a new target language
+     * @param slug the language code
+     * @param name the name of the language
+     * @param anglicizedName the english form of the language name
+     * @param direction the writen direction of the language
+     * @param region the region in which the language belongs
+     * @param isGatewayLanguage indicates if this target language is a gateway language
+     */
+    public TargetLanguage(String slug, String name, String anglicizedName, String direction, String region, boolean isGatewayLanguage) {
+        super(slug, name, direction);
+        this.anglicizedName = anglicizedName;
+        this.region = region;
+        this.isGatewayLanguage = isGatewayLanguage;
+    }
+
+    @Override
+    public JSONObject toJSON() throws JSONException {
+        JSONObject json = super.toJSON();
+        json.put("anglicized_name", anglicizedName);
+        json.put("region", region);
+        json.put("is_gateway_language", isGatewayLanguage);
+        return json;
+    }
+
+    /**
+     * Creates a target language from json
+     * @param json
+     * @return
+     * @throws JSONException
+     */
+    public static TargetLanguage fromJSON(JSONObject json) throws JSONException {
+        Language l = Language.fromJSON(json);
+        // TODO: 9/29/16  parse other info
+        TargetLanguage targetLanguage = new TargetLanguage(l.slug,
+                l.name,
+                json.getString("anglicized_name"),
+                l.direction,
+                json.getString("region"),
+                json.getBoolean("is_gateway_language"));
+        return targetLanguage;
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Translation.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Translation.java
@@ -1,0 +1,45 @@
+package org.unfoldingword.door43client.models;
+
+import org.unfoldingword.resourcecontainer.ContainerTools;
+import org.unfoldingword.resourcecontainer.Language;
+import org.unfoldingword.resourcecontainer.Project;
+import org.unfoldingword.resourcecontainer.Resource;
+import org.unfoldingword.resourcecontainer.ResourceContainer;
+
+/**
+ * A Translation is a special abstraction of a ResourceContainer.
+ * Translations are composed of a language, project, and resource.
+ * As such a translation uniquely represents a single resource container,
+ * though the existence of a translation does not demand the existence of a resource container.
+ */
+
+public class Translation {
+    public final Language language;
+    public final Project project;
+    public final Resource resource;
+
+    /**
+     * The slug of the resource container represented by this translation
+     */
+    public final String resourceContainerSlug;
+
+    public Translation(Language language, Project project, Resource resource) {
+        this.language = language;
+        this.project = project;
+        this.resource = resource;
+
+        resourceContainerSlug = ContainerTools.makeSlug(language.slug, project.slug, resource.slug);
+    }
+
+    /**
+     * Creates a translation from a resource container
+     * @param container
+     */
+    public Translation(ResourceContainer container) {
+        this.language = container.language;
+        this.project = container.project;
+        this.resource = container.resource;
+
+        resourceContainerSlug = ContainerTools.makeSlug(language.slug, project.slug, resource.slug);
+    }
+}

--- a/app/src/main/java/org/unfoldingword/door43client/models/Versification.java
+++ b/app/src/main/java/org/unfoldingword/door43client/models/Versification.java
@@ -1,0 +1,17 @@
+package org.unfoldingword.door43client.models;
+
+/**
+ * Represents a versification system.
+ * This is what chunk markers are based on.
+ */
+public class Versification {
+    public String slug;
+    public String name;
+    public long rowId = -1;
+
+    public Versification(String slug, String name) {
+        this.slug = slug;
+        this.name = name;
+    }
+
+}

--- a/app/src/main/res/menu/menu_new_target_translation.xml
+++ b/app/src/main/res/menu/menu_new_target_translation.xml
@@ -13,7 +13,10 @@
         android:orderInCategory="200"
         android:title="@string/request_new_language"
         android:icon="@drawable/ic_add_white_24dp"
-        app:showAsAction="ifRoom"/>
+        android:checkable="false"
+        android:enabled="false"
+        android:visible="false"
+        app:showAsAction="ifRoom" />
     <item
         android:id="@+id/action_update"
         android:orderInCategory="300"

--- a/app/src/main/res/values/servers.xml
+++ b/app/src/main/res/values/servers.xml
@@ -36,12 +36,13 @@
         <item>https://door43.org/u</item>
     </string-array>
 
-    <string-array name="content_server_lang_names_url_array">
-        <item>https://langnames-temp.walink.org/langnames.json</item>
-    </string-array>
-
     <string-array name="content_server_account_create_urls_array">
         <item>https://content.bibletranslationtools.org/user/sign_up</item>
         <item>https://git.door43.org/user/sign_up</item>
+    </string-array>
+
+    <string-array name="content_server_lang_names_url_array">
+        <item>https://langnames-temp.walink.org/langnames.json</item>
+        <item>https://td.unfoldingword.org/exports/langnames.json</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/servers.xml
+++ b/app/src/main/res/values/servers.xml
@@ -36,6 +36,10 @@
         <item>https://door43.org/u</item>
     </string-array>
 
+    <string-array name="content_server_lang_names_url_array">
+        <item>https://langnames-temp.walink.org/langnames.json</item>
+    </string-array>
+
     <string-array name="content_server_account_create_urls_array">
         <item>https://content.bibletranslationtools.org/user/sign_up</item>
         <item>https://git.door43.org/user/sign_up</item>

--- a/app/src/main/res/values/servers.xml
+++ b/app/src/main/res/values/servers.xml
@@ -42,7 +42,7 @@
     </string-array>
 
     <string-array name="content_server_lang_names_url_array">
-        <item>https://langnames-temp.walink.org/langnames.json</item>
+        <item>https://langnames.bibleineverylanguage.org/langnames.json</item>
         <item>https://td.unfoldingword.org/exports/langnames.json</item>
     </string-array>
 </resources>

--- a/app/src/main/res/values/strings_user_pref.xml
+++ b/app/src/main/res/values/strings_user_pref.xml
@@ -59,6 +59,8 @@
     <string name="pref_title_media_server">Media Server</string>
     <!-- The server used to review translation work in reader -->
     <string name="pref_title_reader_server">Reader Server</string>
+    <!-- The URL to download the list of languages -->
+    <string name="pref_title_language_url">Language URL</string>
     <!-- The URL to create a new account. -->
     <string name="pref_title_create_account_url">Account Creation URL</string>
 

--- a/app/src/main/res/values/strings_user_pref_values.xml
+++ b/app/src/main/res/values/strings_user_pref_values.xml
@@ -40,6 +40,8 @@
 
     <string name="pref_default_reader_server" translatable="false">http://read.bibletranslationtools.org/u</string>
 
+    <string name="pref_default_language_url" translatable="false">https://langnames-temp.walink.org/langnames.json</string>
+
     <string name="pref_default_create_account_url" translatable="false">https://content.bibletranslationtools.org/user/sign_up</string>
 
     <!--<string name="pref_default_export_format" translatable="false">dokuwiki</string>-->

--- a/app/src/main/res/values/strings_user_pref_values.xml
+++ b/app/src/main/res/values/strings_user_pref_values.xml
@@ -40,9 +40,9 @@
 
     <string name="pref_default_reader_server" translatable="false">http://read.bibletranslationtools.org/u</string>
 
-    <string name="pref_default_language_url" translatable="false">https://langnames-temp.walink.org/langnames.json</string>
-
     <string name="pref_default_create_account_url" translatable="false">https://content.bibletranslationtools.org/user/sign_up</string>
+
+    <string name="pref_default_language_url" translatable="false">https://langnames-temp.walink.org/langnames.json</string>
 
     <!--<string name="pref_default_export_format" translatable="false">dokuwiki</string>-->
     <!--<string-array name="pref_export_format_values" translatable="false">-->

--- a/app/src/main/res/values/strings_user_pref_values.xml
+++ b/app/src/main/res/values/strings_user_pref_values.xml
@@ -42,7 +42,7 @@
 
     <string name="pref_default_create_account_url" translatable="false">https://content.bibletranslationtools.org/user/sign_up</string>
 
-    <string name="pref_default_language_url" translatable="false">https://langnames-temp.walink.org/langnames.json</string>
+    <string name="pref_default_language_url" translatable="false">https://langnames.bibleineverylanguage.org/langnames.json</string>
 
     <!--<string name="pref_default_export_format" translatable="false">dokuwiki</string>-->
     <!--<string-array name="pref_export_format_values" translatable="false">-->

--- a/app/src/main/res/xml/server_preferences.xml
+++ b/app/src/main/res/xml/server_preferences.xml
@@ -49,12 +49,12 @@
         android:defaultValue="@string/pref_default_reader_server"/>
 
     <EditTextPreference
-        android:key="lang_names_url"
-        android:title="@string/pref_title_language_url"
-        android:defaultValue="@string/pref_default_language_url"/>
-
-    <EditTextPreference
         android:key="create_account_url"
         android:title="@string/pref_title_create_account_url"
         android:defaultValue="@string/pref_default_create_account_url"/>
+
+    <EditTextPreference
+        android:key="lang_names_url"
+        android:title="@string/pref_title_language_url"
+        android:defaultValue="@string/pref_default_language_url"/>
 </PreferenceScreen>

--- a/app/src/main/res/xml/server_preferences.xml
+++ b/app/src/main/res/xml/server_preferences.xml
@@ -49,6 +49,11 @@
         android:defaultValue="@string/pref_default_reader_server"/>
 
     <EditTextPreference
+        android:key="lang_names_url"
+        android:title="@string/pref_title_language_url"
+        android:defaultValue="@string/pref_default_language_url"/>
+
+    <EditTextPreference
         android:key="create_account_url"
         android:title="@string/pref_title_create_account_url"
         android:defaultValue="@string/pref_default_create_account_url"/>


### PR DESCRIPTION
We integrated [door43-client v0.10.3](https://github.com/unfoldingWord-dev/android-door43-client) library into Writer Android as the catalog URL of `langnames.json` was not configurable in the library above. We change the endpoint and keep the library source code local in our repo.

This also adds a fix to the `truncateTable()` method in `org/unfoldingword/door43client/Library.java` which did not clear the table when executed inside a transaction. See https://github.com/Bible-Translation-Tools/BTT-Writer-Android/pull/79/commits/4938a7189eb3d559c36b448893306afc5477b58d
