### PR TITLE
Insert \p tag before first verse when export USFM

### DIFF
--- a/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
+++ b/app/src/main/java/com/door43/translationstudio/core/ExportUsfm.java
@@ -129,6 +129,8 @@ public class ExportUsfm {
                 ps.println(chapterRef);
             }
 
+            ps.println("\\p"); // paragraph marker
+
             ArrayList<FrameTranslation> frameList = sortFrameTranslations(frames);
             int startChunk = 0;
             if(frameList.size() > 0) {


### PR DESCRIPTION
Fixes #98 .

Changes in this pull request:
- Add \p tag before first verse when export to USFM