### PR TITLE
Fix crashes from stale positions in source selection dialogs

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdk 26
         compileSdk 35
         targetSdk 35
-        versionCode 50
+        versionCode 51
         versionName "1.6.0"
 
         testBuildType "verify"

--- a/app/src/androidTest/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapterTest.kt
+++ b/app/src/androidTest/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapterTest.kt
@@ -1,0 +1,237 @@
+package com.door43.translationstudio.ui.dialogs
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.door43.translationstudio.IntegrationTest
+import com.door43.translationstudio.R
+import com.door43.translationstudio.core.Typography
+import com.door43.translationstudio.ui.dialogs.DownloadSourcesAdapter.FilterStep
+import com.door43.translationstudio.ui.dialogs.DownloadSourcesAdapter.SelectionType
+import com.door43.usecases.GetAvailableSources
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Assert.assertNull
+import org.junit.Assert.assertTrue
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.unfoldingword.door43client.models.Translation
+import org.unfoldingword.resourcecontainer.Language
+import org.unfoldingword.resourcecontainer.Project
+import org.unfoldingword.resourcecontainer.Resource
+import javax.inject.Inject
+
+/**
+ * Verifies the download sources adapter tolerates stale positions and filter rows.
+ *
+ * The item list is rebuilt on every filter step, search and selection change, so a position
+ * captured earlier - or a position held by the download result callback - may be out of range
+ * or point at a filter row, which carries no resource container.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@IntegrationTest
+class DownloadSourcesAdapterTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject lateinit var typography: Typography
+
+    private lateinit var adapter: DownloadSourcesAdapter
+    private lateinit var sources: List<Translation>
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        sources = listOf(
+            translation("en", "English", "gen", "Genesis"),
+            translation("en", "English", "mat", "Matthew"),
+            translation("fr", "français", "gen", "Genèse")
+        )
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            adapter = DownloadSourcesAdapter(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                typography
+            )
+            adapter.setData(
+                GetAvailableSources.Result(
+                    sources,
+                    mapOf("en" to listOf(0, 1), "fr" to listOf(2)),
+                    mapOf("gen" to listOf(0, 2)),
+                    mapOf("mat" to listOf(1)),
+                    mapOf()
+                )
+            )
+        }
+    }
+
+    /**
+     * The download result callback used to look up positions and dereference the container slug
+     * of every row. Filter rows have no container, so the lookup crashed with a
+     * NullPointerException whenever the user had navigated back to a filter list.
+     */
+    @Test
+    fun findPositionOnCategoryListDoesNotCrash() = onMainSync {
+        showCategories()
+
+        assertEquals("Categories should be listed", 2, adapter.count)
+        assertEquals("Unknown slug should not be found", -1, adapter.findPosition(sourceSlug(0)))
+        assertEquals("Null slug should not be found", -1, adapter.findPosition(null))
+    }
+
+    /**
+     * The download result must still land on the item when the list was rebuilt meanwhile.
+     */
+    @Test
+    fun markItemDownloadedBySlug() = onMainSync {
+        showSources()
+
+        val slug = sourceSlug(0)
+        adapter.markItemDownloaded(slug)
+
+        val item = adapter.getItemBySlug(slug)
+        assertNotNull(item)
+        assertTrue("Item should be downloaded", item.downloaded)
+        assertTrue("Downloaded list should contain the slug", adapter.downloaded.contains(slug))
+    }
+
+    /**
+     * A download that finishes while a filter list is shown must not be lost.
+     */
+    @Test
+    fun markItemDownloadedBySlugWhileFilterListShown() = onMainSync {
+        showCategories()
+
+        val slug = sourceSlug(0)
+        adapter.markItemDownloaded(slug)
+        assertTrue("Downloaded list should contain the slug", adapter.downloaded.contains(slug))
+
+        showSources()
+
+        val item = adapter.getItemBySlug(slug)
+        assertNotNull(item)
+        assertTrue("Downloaded state should be restored", item.downloaded)
+    }
+
+    @Test
+    fun markItemErrorBySlugWhileFilterListShown() = onMainSync {
+        showCategories()
+
+        val slug = sourceSlug(0)
+        adapter.markItemError(slug, "download failed")
+
+        showSources()
+
+        val item = adapter.getItemBySlug(slug)
+        assertNotNull(item)
+        assertTrue("Error state should be restored", item.error)
+        assertEquals("download failed", item.errorMessage)
+    }
+
+    /**
+     * Out of range positions used to throw IndexOutOfBoundsException from items.get(position).
+     */
+    @Test
+    fun outOfRangePositionsAreIgnored() = onMainSync {
+        showSources()
+        val count = adapter.count
+
+        assertNull("Out of range item should be null", adapter.getItem(count + 5))
+        assertNull("Negative position should be null", adapter.getItem(-1))
+
+        adapter.toggleSelection(count + 5)
+        adapter.select(count + 5)
+        adapter.deselect(count + 5)
+        adapter.markItemDownloaded(count + 5)
+        adapter.markItemError(count + 5, "boom")
+
+        assertEquals("Nothing should be selected", 0, adapter.selected.size)
+        assertEquals("Nothing should be downloaded", 0, adapter.downloaded.size)
+    }
+
+    /**
+     * Filter rows carry no resource container, so they must never enter the selection.
+     */
+    @Test
+    fun filterRowsAreNotSelectable() = onMainSync {
+        showCategories()
+
+        adapter.toggleSelection(0)
+        adapter.forceSelection(true, false)
+
+        assertEquals("Filter rows should not be selected", 0, adapter.selected.size)
+        assertFalse("Selection should not contain nulls", adapter.selected.contains(null))
+    }
+
+    @Test
+    fun sourceRowsAreStillSelectable() = onMainSync {
+        showSources()
+
+        adapter.toggleSelection(0)
+
+        val slug = adapter.getItem(0).containerSlug
+        assertEquals("Item should be selected", listOf(slug), adapter.selected)
+
+        adapter.toggleSelection(0)
+        assertEquals("Item should be deselected", 0, adapter.selected.size)
+    }
+
+    /** shows the category list, whose rows carry no resource container */
+    private fun showCategories() {
+        adapter.setFilterSteps(
+            listOf(
+                languageStep("en"),
+                FilterStep(SelectionType.book_type, "categories")
+            ),
+            null,
+            true
+        )
+    }
+
+    /** shows the english old testament sources */
+    private fun showSources() {
+        adapter.setFilterSteps(
+            listOf(
+                languageStep("en"),
+                categoryStep(),
+                FilterStep(SelectionType.source_filtered_by_language, "sources")
+            ),
+            null,
+            true
+        )
+    }
+
+    private fun languageStep(languageSlug: String): FilterStep {
+        return FilterStep(SelectionType.language, "language").apply { filter = languageSlug }
+    }
+
+    private fun categoryStep(): FilterStep {
+        return FilterStep(SelectionType.book_type, "category").apply {
+            filter = R.string.old_testament_label.toString()
+        }
+    }
+
+    private fun sourceSlug(index: Int): String = sources[index].resourceContainerSlug
+
+    private fun onMainSync(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    private fun translation(
+        languageSlug: String,
+        languageName: String,
+        projectSlug: String,
+        projectName: String
+    ): Translation {
+        return Translation(
+            Language(languageSlug, languageName, "ltr"),
+            Project(projectSlug, projectName, 1),
+            Resource("ulb", "Unlocked Literal Bible", "book", "all", "3", "5")
+        )
+    }
+}

--- a/app/src/androidTest/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapterTest.kt
+++ b/app/src/androidTest/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapterTest.kt
@@ -1,0 +1,208 @@
+package com.door43.translationstudio.ui.translate
+
+import androidx.test.ext.junit.runners.AndroidJUnit4
+import androidx.test.platform.app.InstrumentationRegistry
+import com.door43.translationstudio.IntegrationTest
+import com.door43.translationstudio.core.Typography
+import com.door43.translationstudio.ui.translate.ChooseSourceTranslationAdapter.RCItem
+import dagger.hilt.android.testing.HiltAndroidRule
+import dagger.hilt.android.testing.HiltAndroidTest
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertNotNull
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.unfoldingword.door43client.models.Translation
+import org.unfoldingword.resourcecontainer.Language
+import org.unfoldingword.resourcecontainer.Project
+import org.unfoldingword.resourcecontainer.Resource
+import javax.inject.Inject
+
+/**
+ * Verifies the adapter tolerates stale positions coming from asynchronous callbacks
+ * (download finished, container deleted, update check finished).
+ *
+ * The list is re-sorted on every selection change, search keystroke, download and delete,
+ * so a position captured when a row was bound may point at a section header - or past the
+ * end of the list - by the time the callback fires.
+ */
+@HiltAndroidTest
+@RunWith(AndroidJUnit4::class)
+@IntegrationTest
+class ChooseSourceTranslationAdapterTest {
+
+    @get:Rule(order = 0)
+    var hiltRule = HiltAndroidRule(this)
+
+    @Inject lateinit var typography: Typography
+
+    private lateinit var adapter: ChooseSourceTranslationAdapter
+
+    @Before
+    fun setUp() {
+        hiltRule.inject()
+        InstrumentationRegistry.getInstrumentation().runOnMainSync {
+            adapter = ChooseSourceTranslationAdapter(
+                InstrumentationRegistry.getInstrumentation().targetContext,
+                typography
+            )
+            adapter.setItems(testItems())
+        }
+    }
+
+    /**
+     * Reproduces the crash reported as
+     * NullPointerException: Attempt to read from field 'boolean RCItem.downloaded' on a null
+     * object reference in ChooseSourceTranslationAdapter.getItemViewType(int)
+     *
+     * A download completes and the adapter is told to mark the item downloaded using the
+     * position captured before the list was re-sorted. That position now holds a section
+     * header, whose containerSlug is null, so a null slug is pushed into the selected list
+     * and the next sort inserts a null element into the sorted data.
+     */
+    @Test
+    fun markItemDownloadedWithStalePositionOnHeader() = onMainSync {
+        adapter.applySearch("zzzz") // only the three section headers survive
+        assertEquals("Only section headers should remain", 3, adapter.count)
+
+        adapter.markItemDownloaded(0) // stale position - row 0 is the "selected" header
+
+        assertNoNullItems()
+        // would throw NullPointerException before the fix
+        for (i in 0 until adapter.count) adapter.getItemViewType(i)
+    }
+
+    /**
+     * Same as above but through the long press delete flow, which pushes the null slug
+     * into the downloadable list instead.
+     */
+    @Test
+    fun markItemDeletedWithStalePositionOnHeader() = onMainSync {
+        adapter.applySearch("zzzz")
+        assertEquals("Only section headers should remain", 3, adapter.count)
+
+        adapter.markItemDeleted(0)
+
+        assertNoNullItems()
+        for (i in 0 until adapter.count) adapter.getItemViewType(i)
+    }
+
+    /**
+     * The update check result carries a position too, and its live data is re-delivered
+     * after a configuration change, when the list may be shorter than it used to be.
+     */
+    @Test
+    fun setItemHasUpdatesWithOutOfRangePosition() = onMainSync {
+        adapter.applySearch("zzzz")
+
+        adapter.setItemHasUpdates(adapter.count + 5, true) // would throw before the fix
+
+        assertNoNullItems()
+    }
+
+    /**
+     * Toggling a stale position that now points at a header must not corrupt the list.
+     */
+    @Test
+    fun toggleSelectionWithStalePositionOnHeader() = onMainSync {
+        adapter.applySearch("zzzz")
+
+        adapter.toggleSelection(0)
+        adapter.toggleSelection(adapter.count + 5)
+
+        assertNoNullItems()
+        for (i in 0 until adapter.count) adapter.getItemViewType(i)
+    }
+
+    /**
+     * A header must never be reported as selectable, and selecting real items must
+     * keep working after the stale position calls above.
+     */
+    @Test
+    fun realItemsStillSelectableAfterStalePositionCalls() = onMainSync {
+        adapter.markItemDownloaded(0)
+        adapter.markItemDeleted(0)
+
+        val position = firstSelectablePosition()
+        assertNotNull("There should be a selectable item", position)
+        adapter.toggleSelection(position!!)
+
+        assertNoNullItems()
+        assertEquals("Item should be selected", true, adapter.getItem(
+            firstSelectablePosition()!!
+        ).selected)
+    }
+
+    /**
+     * The search filter applies to every section, including the selected one,
+     * but hidden selections must still be reported back to the caller.
+     */
+    @Test
+    fun searchFiltersSelectedItemsWithoutLosingThem() = onMainSync {
+        val position = firstSelectablePosition()!!
+        val slug = adapter.getItem(position).containerSlug
+        adapter.toggleSelection(position)
+        assertEquals("Item should be selected", listOf(slug), adapter.selectedSlugs)
+
+        adapter.applySearch("zzzz")
+
+        assertEquals("Selected item should be filtered out", 3, adapter.count)
+        assertEquals("Selection should be kept", listOf(slug), adapter.selectedSlugs)
+
+        adapter.applySearch("")
+
+        assertEquals("Selected item should be listed again", slug, adapter.getItem(1).containerSlug)
+        assertEquals("Selection should be kept", listOf(slug), adapter.selectedSlugs)
+    }
+
+    private fun firstSelectablePosition(): Int? {
+        for (i in 0 until adapter.count) {
+            val item = adapter.getItem(i)
+            if (item != null && item.containerSlug != null && item.downloaded) return i
+        }
+        return null
+    }
+
+    private fun assertNoNullItems() {
+        for (i in 0 until adapter.count) {
+            assertNotNull("Sorted data should not contain null items", adapter.getItem(i))
+        }
+        assertFalse(
+            "Out of range positions should not be selectable",
+            adapter.isSelectableItem(adapter.count + 5)
+        )
+    }
+
+    private fun onMainSync(block: () -> Unit) {
+        InstrumentationRegistry.getInstrumentation().runOnMainSync(block)
+    }
+
+    private fun testItems(): List<RCItem> {
+        return listOf(
+            rcItem("en", "English", downloaded = true, selected = false),
+            rcItem("es-419", "Español Latin America", downloaded = true, selected = false),
+            rcItem("fr", "français", downloaded = false, selected = false)
+        )
+    }
+
+    private fun rcItem(
+        languageSlug: String,
+        languageName: String,
+        downloaded: Boolean,
+        selected: Boolean
+    ): RCItem {
+        val translation = Translation(
+            Language(languageSlug, languageName, "ltr"),
+            Project("gen", "Genesis", 1),
+            Resource("ulb", "Unlocked Literal Bible", "book", "all", "3", "5")
+        )
+        return RCItem(
+            "$languageName - ${translation.resource.name}",
+            translation,
+            selected,
+            downloaded
+        )
+    }
+}

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesAdapter.java
@@ -43,7 +43,7 @@ public class DownloadSourcesAdapter extends BaseAdapter {
     public static final String TAG = DownloadSourcesAdapter.class.getSimpleName();
     public static final int TYPE_ITEM_FILTER_SELECTION = 0;
     public static final int TYPE_ITEM_SOURCE_SELECTION = 1;
-    private Context context;
+    private final Context context;
     private List<String> selected = new ArrayList<>();
     private List<String> downloaded = new ArrayList<>();
     private List<ViewItem> items = new ArrayList<>();
@@ -74,7 +74,8 @@ public class DownloadSourcesAdapter extends BaseAdapter {
 
     private final Typography typography;
 
-    public DownloadSourcesAdapter(Typography typography) {
+    public DownloadSourcesAdapter(Context context, Typography typography) {
+        this.context = context;
         this.typography = typography;
     }
 
@@ -123,9 +124,34 @@ a     * @param task
         initializeSelections();
     }
 
+    /**
+     * Returns the item at the given position, or null if the position is out of range.
+     * Positions are unstable because the list is rebuilt on every filter step, search and
+     * selection change, so asynchronous callers may hold a position that no longer exists.
+     * @param position
+     * @return
+     */
     @Override
     public ViewItem getItem(int position) {
-        return items.get(position);
+        if(position >= 0 && position < items.size()) {
+            return items.get(position);
+        }
+        return null;
+    }
+
+    /**
+     * Finds an item by its container slug.
+     * @param containerSlug
+     * @return the item or null if it is not in the list
+     */
+    public ViewItem getItemBySlug(String containerSlug) {
+        if(containerSlug == null) return null;
+        for (ViewItem item : items) {
+            if(containerSlug.equals(item.containerSlug)) {
+                return item;
+            }
+        }
+        return null;
     }
 
     @Override
@@ -355,6 +381,8 @@ a     * @param task
         boolean found = false;
         if(sortSet.containsKey(languageFilter)) {
             List<Integer> items = sortSet.get(languageFilter);
+            if (items == null) return false;
+
             for (Integer index : items) {
                 if ((index >= 0) && (index < availableSources.size())) {
                     Translation sourceTranslation = availableSources.get(index);
@@ -405,12 +433,8 @@ a     * @param task
         }
 
         // sort by language code
-        Collections.sort(items, new Comparator<ViewItem>() { // do numeric sort
-            @Override
-            public int compare(ViewItem lhs, ViewItem rhs) {
-                return lhs.filter.compareTo(rhs.filter);
-            }
-        });
+        // do numeric sort
+        items.sort(Comparator.comparing(lhs -> lhs.filter));
     }
 
     /**
@@ -549,13 +573,12 @@ a     * @param task
         if(sort) {
             // do numeric sort
             // do numeric sort
-            Collections.sort(items, (lhs, rhs) -> lhs.title.toString().compareTo(rhs.title.toString()));
+            items.sort(Comparator.comparing(lhs -> lhs.title.toString()));
         }
     }
 
     @Override
     public View getView(final int position, View convertView, ViewGroup parent) {
-        context = parent.getContext();
         final LayoutInflater inflater = LayoutInflater.from(parent.getContext());
 
         int rowType = getItemViewType(position);
@@ -584,7 +607,9 @@ a     * @param task
             viewHolder = (BaseViewHolder) convertView.getTag();
         }
 
-        viewHolder.bind(item);
+        if(item != null) {
+            viewHolder.bind(item);
+        }
 
         return viewHolder.binding.getRoot();
     }
@@ -594,43 +619,66 @@ a     * @param task
      * @param position
      */
     public void toggleSelection(int position) {
-        if(getItem(position).selected) {
-            deselect(position);
+        ViewItem item = getSelectableItem(position);
+        if(item == null) return;
+
+        if(item.selected) {
+            deselect(item);
         } else {
-            select(position);
+            select(item);
         }
         notifyDataSetChanged();
     }
 
     public void select(int position) {
-        ViewItem item = getItem(position);
-        if(item != null) {
-            if(!item.downloaded) {
-                item.selected = true;
-                if (!selected.contains(item.containerSlug)) { // make sure we don't add entry twice (particularly during select all)
-                    selected.add(item.containerSlug);
-                }
+        select(getSelectableItem(position));
+    }
+
+    public void deselect(int position) {
+        deselect(getSelectableItem(position));
+    }
+
+    private void select(ViewItem item) {
+        if(item == null || item.containerSlug == null) return;
+
+        if(!item.downloaded) {
+            item.selected = true;
+            if (!selected.contains(item.containerSlug)) { // make sure we don't add entry twice (particularly during select all)
+                selected.add(item.containerSlug);
             }
         }
     }
 
-    public void deselect(int position) {
+    private void deselect(ViewItem item) {
+        if(item == null || item.containerSlug == null) return;
+
+        item.selected = false;
+        selected.remove(item.containerSlug);
+    }
+
+    /**
+     * Returns the item at the given position only if it represents a resource container.
+     * Filter rows (languages, categories, books) and out of range positions resolve to null.
+     * @param position
+     * @return
+     */
+    private ViewItem getSelectableItem(int position) {
         ViewItem item = getItem(position);
-        if(item != null) {
-            item.selected = false;
-            selected.remove(item.containerSlug);
-        }
+        if(item == null || item.containerSlug == null) return null;
+        return item;
     }
 
     /**
      * search items for position that matches slug
      * @param slug
-     * @return
+     * @return the position or -1 if the slug is not in the list
      */
     public int findPosition(String slug) {
+        if(slug == null) return -1;
         for (int i = 0; i < items.size(); i++) {
             ViewItem item = items.get(i);
-            if(item.containerSlug.equals(slug)) {
+            // filter rows have no container slug
+            if(slug.equals(item.containerSlug)) {
                 return i;
             }
         }
@@ -642,11 +690,35 @@ a     * @param task
      * @param position
      */
     public void markItemDownloaded(int position) {
-        ViewItem item = getItem(position);
+        markItemDownloaded(getSelectableItem(position));
+    }
+
+    /**
+     * marks an item as downloaded
+     * The state is recorded even when the item is not in the currently filtered list,
+     * so it is restored once the list is rebuilt.
+     * @param containerSlug
+     */
+    public void markItemDownloaded(String containerSlug) {
+        if(containerSlug == null) return;
+
+        ViewItem item = getItemBySlug(containerSlug);
         if(item != null) {
+            markItemDownloaded(item);
+            return;
+        }
+        if(!downloaded.contains(containerSlug)) {
+            downloaded.add(containerSlug);
+        }
+        selected.remove(containerSlug);
+        downloadErrors.remove(containerSlug);
+    }
+
+    private void markItemDownloaded(ViewItem item) {
+        if(item != null && item.containerSlug != null) {
             item.downloaded = true;
             item.error = false;
-            deselect(position);
+            deselect(item);
 
             if(!downloaded.contains(item.containerSlug)) {
                 downloaded.add(item.containerSlug);
@@ -660,8 +732,29 @@ a     * @param task
      * @param position
      */
     public void markItemError(int position, String message) {
-        ViewItem item = getItem(position);
+        markItemError(getSelectableItem(position), message);
+    }
+
+    /**
+     * marks an item as error
+     * The state is recorded even when the item is not in the currently filtered list,
+     * so it is restored once the list is rebuilt.
+     * @param containerSlug
+     */
+    public void markItemError(String containerSlug, String message) {
+        if(containerSlug == null) return;
+
+        ViewItem item = getItemBySlug(containerSlug);
         if(item != null) {
+            markItemError(item, message);
+            return;
+        }
+        downloadErrors.put(containerSlug, message);
+        downloaded.remove(containerSlug);
+    }
+
+    private void markItemError(ViewItem item, String message) {
+        if(item != null && item.containerSlug != null) {
             item.error = true;
             item.errorMessage = message;
 
@@ -798,7 +891,7 @@ a     * @param task
         source_filtered_by_language(5),
         source_filtered_by_book(6);
 
-        private int _value;
+        private final int _value;
 
         SelectionType(int Value) {
             this._value = Value;
@@ -821,7 +914,7 @@ a     * @param task
     public enum SelectedState {
         all,
         none,
-        not_empty;
+        not_empty
     }
 
     private abstract static class BaseViewHolder {
@@ -854,12 +947,14 @@ a     * @param task
             } else {
                 binding.itemIcon.setVisibility(View.GONE);
                 // if language selection, look up font
-                Typeface typeface = typography.getBestFontForLanguage(
-                        TranslationType.SOURCE,
-                        item.sourceTranslation.language.slug,
-                        item.sourceTranslation.language.direction
-                );
-                binding.title.setTypeface(typeface, Typeface.NORMAL);
+                if(item.sourceTranslation != null) {
+                    Typeface typeface = typography.getBestFontForLanguage(
+                            TranslationType.SOURCE,
+                            item.sourceTranslation.language.slug,
+                            item.sourceTranslation.language.direction
+                    );
+                    binding.title.setTypeface(typeface, Typeface.NORMAL);
+                }
             }
         }
     }

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.kt
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/DownloadSourcesDialog.kt
@@ -78,7 +78,7 @@ class DownloadSourcesDialog : DialogFragment() {
             false
         )
 
-        adapter = DownloadSourcesAdapter(typography)
+        adapter = DownloadSourcesAdapter(requireContext(), typography)
 
         with(binding) {
             searchBackButton.setOnClickListener {
@@ -121,7 +121,7 @@ class DownloadSourcesDialog : DialogFragment() {
                     if (steps.isNotEmpty()) {
                         searchString = null
                         val currentStep = steps[steps.size - 1]
-                        val item = adapter.getItem(position)
+                        val item = adapter.getItem(position) ?: return@OnItemClickListener
                         currentStep.old_label = currentStep.label
                         currentStep.label = item.title.toString()
                         currentStep.filter = item.filter
@@ -571,22 +571,17 @@ class DownloadSourcesDialog : DialogFragment() {
             for (slug in downloadedTranslations) {
                 Logger.i(TAG, "Received: $slug")
 
-                val pos = adapter.findPosition(slug)
-                if (pos >= 0) {
-                    adapter.markItemDownloaded(pos)
-                }
+                // by slug, the list may have been rebuilt while the download was running
+                adapter.markItemDownloaded(slug)
             }
 
             val failedSourceDownloads = result.failedSourceDownloads
             for (translationID in failedSourceDownloads) {
                 Logger.e(TAG, "Download failed: $translationID")
-                val pos = adapter.findPosition(translationID)
-                if (pos >= 0) {
-                    adapter.markItemError(
-                        pos,
-                        result.failureMessages[translationID]
-                    )
-                }
+                adapter.markItemError(
+                    translationID,
+                    result.failureMessages[translationID]
+                )
             }
 
             val downloads = resources.getString(

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationAdapter.java
@@ -1,10 +1,7 @@
 package com.door43.translationstudio.ui.translate;
 
 import android.content.Context;
-import android.graphics.Bitmap;
-import android.graphics.BitmapFactory;
 import android.graphics.Typeface;
-import android.graphics.drawable.BitmapDrawable;
 import android.graphics.drawable.Drawable;
 import android.text.Spannable;
 import android.text.SpannableStringBuilder;
@@ -65,21 +62,20 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
     private OnItemClickListener itemClickListener = null;
 
     public interface OnItemClickListener {
-        void onCheckForItemUpdates(String containerSlug, int position);
-        void onTriggerDownload(RCItem item, int position, Callbacks.OnDownloadCancel callback);
+        void onCheckForItemUpdates(String containerSlug);
+        void onTriggerDownload(RCItem item, Callbacks.OnDownloadCancel callback);
         void onTriggerDeleteContainer(
                 String containerSlug,
-                int position,
                 Callbacks.OnDeleteContainer callback
         );
     }
 
     public interface Callbacks {
         interface OnDownloadCancel {
-            void onCancel(int position);
+            void onCancel(String containerSlug);
         }
         interface OnDeleteContainer {
-            void onDelete(int position);
+            void onDelete(String containerSlug);
         }
     }
 
@@ -134,14 +130,48 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
     }
 
     /**
+     * Finds an item by its container slug.
+     * Positions are unstable because the list is resorted on every change,
+     * so the slug is the only safe way to refer to an item from an asynchronous callback.
+     * @param containerSlug
+     * @return the item or null if it is not in the list
+     */
+    public RCItem getItemBySlug(String containerSlug) {
+        if(containerSlug == null) return null;
+        return data.get(containerSlug);
+    }
+
+    /**
+     * The slugs of all selected items.
+     * Selections are kept even when the search filter hides them from the list.
+     * @return
+     */
+    public List<String> getSelectedSlugs() {
+        return new ArrayList<>(selected);
+    }
+
+    /**
      * toggle selection state for item
      * @param position
      */
     public void toggleSelection(int position) {
-        if(getItem(position).selected) {
-            deselect(position);
+        toggleSelection(getSelectableItem(position));
+    }
+
+    /**
+     * toggle selection state for item
+     * @param containerSlug
+     */
+    public void toggleSelection(String containerSlug) {
+        toggleSelection(getItemBySlug(containerSlug));
+    }
+
+    private void toggleSelection(RCItem item) {
+        if(item == null) return;
+        if(item.selected) {
+            deselect(item);
         } else {
-            select(position);
+            select(item);
         }
         sort();
     }
@@ -155,18 +185,32 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         return getItemViewType(position) != TYPE_SEPARATOR;
     }
 
+    /**
+     * Returns the item at the given position only if it is a real, selectable item.
+     * Section headers and out of range positions resolve to null.
+     * @param position
+     * @return
+     */
+    private RCItem getSelectableItem(int position) {
+        RCItem item = getItem(position);
+        if(item == null || item.containerSlug == null) return null;
+        return item;
+    }
+
     @Override
     public int getItemViewType(int position) {
-        int type = sectionHeader.contains(position) ? TYPE_SEPARATOR : TYPE_ITEM_SELECTABLE;
-        if(type == TYPE_ITEM_SELECTABLE) {
-            RCItem v = getItem(position);
-            if(!v.downloaded) { // check if we need to download
-                type = TYPE_ITEM_NEED_DOWNLOAD;
-            } else if(v.hasUpdates) {
-                type = TYPE_ITEM_SELECTABLE_UPDATABLE;
-            }
+        RCItem v = getItem(position);
+        // headers, unknown positions and items without a container are not selectable
+        if(sectionHeader.contains(position) || v == null || v.containerSlug == null) {
+            return TYPE_SEPARATOR;
         }
-        return type;
+        if(!v.downloaded) { // check if we need to download
+            return TYPE_ITEM_NEED_DOWNLOAD;
+        }
+        if(v.hasUpdates) {
+            return TYPE_ITEM_SELECTABLE_UPDATABLE;
+        }
+        return TYPE_ITEM_SELECTABLE;
     }
 
     @Override
@@ -194,7 +238,7 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         sortedData.add(selectedHeader);
         sectionHeader.add(sortedData.size() - 1);
 
-        List<RCItem> section = getViewItems(selected, null); // do not restrict selections by search string
+        List<RCItem> section = getViewItems(selected, searchText);
         sortedData.addAll(section);
 
         RCItem availableHeader = new RCItem(context.getResources().getString(R.string.available), null, false, false);
@@ -222,7 +266,10 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
     private List<RCItem> getViewItems(List<String> data, String searchText) {
         List<RCItem> section = new ArrayList<>();
         for(String id:data) {
-            section.add(this.data.get(id));
+            RCItem item = this.data.get(id);
+            if(item != null) { // never place null items in the list
+                section.add(item);
+            }
         }
 
         // sort by language code
@@ -392,6 +439,13 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         // load update status
         holder.currentPosition = position;
 
+        if(item == null) { // list changed under us, render an empty row instead of crashing
+            holder.titleView.setText("");
+            view.setOnClickListener(null);
+            view.setOnLongClickListener(null);
+            return view;
+        }
+
         holder.titleView.setText(item.title);
         if(item.sourceTranslation != null) {
             setFontForLanguage(holder, item);
@@ -420,23 +474,22 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         }
 
         view.setOnClickListener(v -> {
-            if (itemClickListener != null && isSelectableItem(position)) {
+            if (itemClickListener != null && item.containerSlug != null) {
                 if (item.hasUpdates || !item.downloaded) {
-                    itemClickListener.onTriggerDownload(item, position, this::toggleSelection);
+                    itemClickListener.onTriggerDownload(item, this::toggleSelection);
                 } else {
-                    toggleSelection(position);
+                    toggleSelection(item.containerSlug);
                     if (!item.checkedUpdates && item.downloaded) {
-                        itemClickListener.onCheckForItemUpdates(item.containerSlug, position);
+                        itemClickListener.onCheckForItemUpdates(item.containerSlug);
                     }
                 }
             }
         });
 
         view.setOnLongClickListener(v -> {
-            if (itemClickListener != null && item.downloaded && isSelectableItem(position)) {
+            if (itemClickListener != null && item.downloaded && item.containerSlug != null) {
                 itemClickListener.onTriggerDeleteContainer(
                         item.containerSlug,
-                        position,
                         this::markItemDeleted
                 );
                 return true;
@@ -464,12 +517,12 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         }
     }
 
-    private void select(int position) {
+    private void select(RCItem item) {
+        if (item == null || item.containerSlug == null) return;
         if (selected.size() >= MAX_SOURCE_ITEMS) {
             return;
         }
 
-        RCItem item = getItem(position);
         item.selected = true;
         selected.remove(item.containerSlug);
         available.remove(item.containerSlug);
@@ -477,8 +530,9 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
         selected.add(item.containerSlug);
     }
 
-    private void deselect(int position) {
-        RCItem item = getItem(position);
+    private void deselect(RCItem item) {
+        if (item == null || item.containerSlug == null) return;
+
         item.selected = false;
         selected.remove(item.containerSlug);
         available.remove(item.containerSlug);
@@ -490,9 +544,20 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
      * Marks an item as deleted
      * @param position
      */
-    private void markItemDeleted(int position) {
-        RCItem item = getItem(position);
-        if(item != null) {
+    public void markItemDeleted(int position) {
+        markItemDeleted(getSelectableItem(position));
+    }
+
+    /**
+     * Marks an item as deleted
+     * @param containerSlug
+     */
+    public void markItemDeleted(String containerSlug) {
+        markItemDeleted(getItemBySlug(containerSlug));
+    }
+
+    private void markItemDeleted(RCItem item) {
+        if(item != null && item.containerSlug != null) {
             item.hasUpdates = false;
             item.downloaded = false;
             item.selected = false;
@@ -508,11 +573,22 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
      * @param position
      */
     public void markItemDownloaded(int position) {
-        RCItem item = getItem(position);
-        if(item != null) {
+        markItemDownloaded(getSelectableItem(position));
+    }
+
+    /**
+     * marks an item as downloaded
+     * @param containerSlug
+     */
+    public void markItemDownloaded(String containerSlug) {
+        markItemDownloaded(getItemBySlug(containerSlug));
+    }
+
+    private void markItemDownloaded(RCItem item) {
+        if(item != null && item.containerSlug != null) {
             item.hasUpdates = false;
             item.downloaded = true;
-            select(position); // auto select download item
+            select(item); // auto select download item
         }
         sort();
     }
@@ -522,7 +598,16 @@ public class ChooseSourceTranslationAdapter extends BaseAdapter {
     }
 
     public void setItemHasUpdates(int position, boolean hasUpdates) {
-        RCItem item = getItem(position);
+        setItemHasUpdates(getSelectableItem(position), hasUpdates);
+    }
+
+    public void setItemHasUpdates(String containerSlug, boolean hasUpdates) {
+        setItemHasUpdates(getItemBySlug(containerSlug), hasUpdates);
+    }
+
+    private void setItemHasUpdates(RCItem item, boolean hasUpdates) {
+        if(item == null) return;
+
         item.hasUpdates = hasUpdates;
         item.checkedUpdates = true;
         notifyDataSetChanged();

--- a/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.kt
+++ b/app/src/main/java/com/door43/translationstudio/ui/translate/ChooseSourceTranslationDialog.kt
@@ -119,17 +119,8 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
             confirmButton.setOnClickListener {
                 viewModel.cancelJobs()
                 // collect selected source translations
-                val count = adapter.count
-                val resourceContainerSlugs = arrayListOf<String>()
-                for (i in 0 until count) {
-                    if (adapter.isSelectableItem(i)) {
-                        val item = adapter.getItem(i)
-                        if (item.selected) {
-                            resourceContainerSlugs.add(item.containerSlug)
-                        }
-                    }
-                }
-                clickListener?.onConfirmTabsDialog(resourceContainerSlugs)
+                // taken from the adapter data, since the search filter may hide selected items
+                clickListener?.onConfirmTabsDialog(adapter.selectedSlugs)
                 dismiss()
             }
         }
@@ -189,7 +180,7 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
                         resources.getColor(R.color.light_primary_text)
                     )
                     snack.show()
-                    adapter.markItemDownloaded(viewModel.downloadItemPosition)
+                    viewModel.downloadItemSlug?.let(adapter::markItemDownloaded)
                 } else {
                     val snack = Snackbar.make(
                         this@ChooseSourceTranslationDialog.requireView(),
@@ -206,7 +197,7 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
         }
         viewModel.itemResult.observe(this) {
             it?.let { result ->
-                adapter.setItemHasUpdates(result.position, result.hasUpdates)
+                adapter.setItemHasUpdates(result.containerSlug, result.hasUpdates)
             }
         }
     }
@@ -219,13 +210,12 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
         clickListener = listener
     }
 
-    override fun onCheckForItemUpdates(containerSlug: String, position: Int) {
-        viewModel.checkForContainerUpdates(containerSlug, position)
+    override fun onCheckForItemUpdates(containerSlug: String) {
+        viewModel.checkForContainerUpdates(containerSlug)
     }
 
     override fun onTriggerDownload(
         item: RCItem,
-        position: Int,
         callback: Callbacks.OnDownloadCancel
     ) {
         val format = resources.getString(R.string.download_source_language)
@@ -234,12 +224,12 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
             .setTitle(R.string.title_download_source_language)
             .setMessage(message)
             .setPositiveButton(R.string.confirm) { _, _ ->
-                viewModel.downloadResourceContainer(item.sourceTranslation, position)
+                viewModel.downloadResourceContainer(item.sourceTranslation)
             }
             .setNegativeButton(R.string.no) { _, _ ->
                 if (item.downloaded) {
                     // allow selecting if downloaded already
-                    callback.onCancel(position)
+                    callback.onCancel(item.containerSlug)
                 }
             }
             .show()
@@ -247,7 +237,6 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
 
     override fun onTriggerDeleteContainer(
         containerSlug: String,
-        position: Int,
         callback: Callbacks.OnDeleteContainer
     ) {
         AlertDialog.Builder(requireActivity(), R.style.AppTheme_Dialog)
@@ -255,7 +244,7 @@ class ChooseSourceTranslationDialog : DialogFragment(), OnItemClickListener {
             .setMessage(R.string.confirm_delete_project)
             .setPositiveButton(R.string.confirm) { _, _ ->
                 viewModel.deleteResourceContainer(containerSlug)
-                callback.onDelete(position)
+                callback.onDelete(containerSlug)
             }
             .setNegativeButton(R.string.menu_cancel, null)
             .show()

--- a/app/src/main/java/com/door43/translationstudio/ui/viewmodels/ChooseSourcesViewModel.kt
+++ b/app/src/main/java/com/door43/translationstudio/ui/viewmodels/ChooseSourcesViewModel.kt
@@ -53,9 +53,10 @@ class ChooseSourcesViewModel @Inject constructor(
     private val _itemResult = MutableLiveData<ItemResult?>(null)
     val itemResult: LiveData<ItemResult?> = _itemResult
 
-    var downloadItemPosition = 0
+    var downloadItemSlug: String? = null
+        private set
 
-    data class ItemResult(val position: Int, val hasUpdates: Boolean)
+    data class ItemResult(val containerSlug: String, val hasUpdates: Boolean)
 
     fun setTargetTranslation(translationId: String) {
         _targetTranslation = translator.getTargetTranslation(translationId)
@@ -104,9 +105,9 @@ class ChooseSourcesViewModel @Inject constructor(
         }.also(jobs::add)
     }
 
-    fun downloadResourceContainer(sourceTranslation: Translation, position: Int) {
+    fun downloadResourceContainer(sourceTranslation: Translation) {
         viewModelScope.launch {
-            downloadItemPosition = position
+            downloadItemSlug = sourceTranslation.resourceContainerSlug
             _progress.value = ProgressHelper.Progress()
             _downloadResult.value = withContext(Dispatchers.IO) {
                 downloadResourceContainers.download(sourceTranslation) { progress, max, message ->
@@ -131,7 +132,7 @@ class ChooseSourcesViewModel @Inject constructor(
         return prefRepository.getOpenSourceTranslations(targetTranslationId)
     }
 
-    fun checkForContainerUpdates(containerSlug: String, position: Int) {
+    fun checkForContainerUpdates(containerSlug: String) {
         viewModelScope.launch {
             _progress.value = ProgressHelper.Progress()
             _itemResult.value = withContext(Dispatchers.IO) {
@@ -146,10 +147,10 @@ class ChooseSourcesViewModel @Inject constructor(
                         container.project.slug,
                         container.resource.slug
                     )
-                    ItemResult(position, lastModified > container.modifiedAt)
+                    ItemResult(containerSlug, lastModified > container.modifiedAt)
                 } catch (e: Exception) {
                     e.printStackTrace()
-                    ItemResult(position, false)
+                    ItemResult(containerSlug, false)
                 }
             }
             _progress.value = null
@@ -158,6 +159,8 @@ class ChooseSourcesViewModel @Inject constructor(
 
     fun clearResults() {
         _downloadResult.value = null
+        _itemResult.value = null
+        downloadItemSlug = null
     }
 
     /**


### PR DESCRIPTION
Reference list items by container slug instead of position, since both lists are rebuilt on every selection, search, download and delete; also apply the search filter to selected sources.

Fixes #341.

Changes in this pull request:
- Fixed bug that leads to crash on "Choose source" and "Download source" dialogs