### PR TITLE
Handle a remote with no branch when pulling

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -34,7 +34,7 @@ android {
         minSdk 26
         compileSdk 35
         targetSdk 35
-        versionCode 50
+        versionCode 51
         versionName "1.6.0"
 
         testBuildType "verify"

--- a/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.kt
+++ b/app/src/main/java/com/door43/translationstudio/ui/dialogs/BackupDialog.kt
@@ -277,11 +277,12 @@ class BackupDialog : DialogFragment() {
         viewModel.pullTranslationResult.observe(this) {
             it?.let { result ->
                 val status = result.status
-                // TRICKY: we continue to push for unknown status in case
-                // the repo was just created (the missing branch is an error)
-                // the pull task will catch any errors
+                // TRICKY: we continue to push when the remote has no branch yet,
+                // which is the case for a repository that was just created,
+                // and for unknown status, since the pull task logged the cause
                 when (status) {
                     PullTargetTranslation.Status.UP_TO_DATE,
+                    PullTargetTranslation.Status.NO_REMOTE_BRANCH,
                     PullTargetTranslation.Status.UNKNOWN -> {
                         Logger.i(
                             this.javaClass.name,

--- a/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.kt
+++ b/app/src/main/java/com/door43/translationstudio/ui/home/HomeActivity.kt
@@ -299,7 +299,10 @@ class HomeActivity : BaseActivity(),
         viewModel.pullTranslationResult.observe(this) {
             it?.let { result ->
                 val status = result.status
-                if (status == PullTargetTranslation.Status.UP_TO_DATE || status == PullTargetTranslation.Status.UNKNOWN) {
+                if (status == PullTargetTranslation.Status.UP_TO_DATE ||
+                    status == PullTargetTranslation.Status.NO_REMOTE_BRANCH ||
+                    status == PullTargetTranslation.Status.UNKNOWN
+                ) {
                     AlertDialog.Builder(this, R.style.AppTheme_Dialog)
                         .setTitle(R.string.success)
                         .setMessage(R.string.success_translation_update)

--- a/app/src/main/java/com/door43/usecases/PullTargetTranslation.kt
+++ b/app/src/main/java/com/door43/usecases/PullTargetTranslation.kt
@@ -12,6 +12,7 @@ import dagger.hilt.android.qualifiers.ApplicationContext
 import org.eclipse.jgit.api.CheckoutCommand
 import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.errors.CheckoutConflictException
+import org.eclipse.jgit.api.errors.RefNotAdvertisedException
 import org.eclipse.jgit.api.errors.TransportException
 import org.eclipse.jgit.errors.NoRemoteRepositoryException
 import org.eclipse.jgit.merge.MergeStrategy
@@ -111,7 +112,7 @@ class PullTargetTranslation @Inject constructor(
             .setTransportConfigCallback(transportCallback)
             .setRemote("origin")
             .setStrategy(mergeStrategy)
-            .setRemoteBranchName("master")
+            .setRemoteBranchName(REMOTE_BRANCH)
         try {
             val result = pullCommand.call()
             val mergeResult = result.mergeResult
@@ -154,6 +155,14 @@ class PullTargetTranslation @Inject constructor(
                 status = Status.UP_TO_DATE
             }
             return Result(status, "Pulled Successfully!")
+        } catch (e: RefNotAdvertisedException) {
+            // a repository that was just created has no branches yet, so there is nothing
+            // to pull. this is expected and the caller is free to push.
+            Logger.i(
+                this.javaClass.name,
+                "The remote did not advertise the $REMOTE_BRANCH branch, nothing to pull: ${e.message}"
+            )
+            return Result(Status.NO_REMOTE_BRANCH, null)
         } catch (e: TransportException) {
             Logger.e(this.javaClass.name, e.message, e)
             val cause = e.cause
@@ -201,6 +210,11 @@ class PullTargetTranslation @Inject constructor(
         OUT_OF_MEMORY,
         AUTH_FAILURE,
         NO_REMOTE_REPO,
+        NO_REMOTE_BRANCH,
         UNKNOWN
+    }
+
+    companion object {
+        private const val REMOTE_BRANCH = "master"
     }
 }

--- a/app/src/test/java/com/door43/usecases/PullTargetTranslationTest.kt
+++ b/app/src/test/java/com/door43/usecases/PullTargetTranslationTest.kt
@@ -25,6 +25,7 @@ import org.eclipse.jgit.api.Git
 import org.eclipse.jgit.api.MergeResult
 import org.eclipse.jgit.api.PullCommand
 import org.eclipse.jgit.api.PullResult
+import org.eclipse.jgit.api.errors.RefNotAdvertisedException
 import org.eclipse.jgit.api.errors.TransportException
 import org.eclipse.jgit.errors.NoRemoteRepositoryException
 import org.eclipse.jgit.merge.MergeStrategy
@@ -516,6 +517,43 @@ class PullTargetTranslationTest {
         verify { getRepository.execute(any(), any()) }
         verify { targetTranslation.repo }
         verify { targetTranslation.path }
+        verify { pullCommand.call() }
+    }
+
+    @Test
+    fun `test pull target translation, remote has no branch yet`() {
+        every { profile.gogsUser }.returns(mockk())
+
+        val repository: Repository = mockk {
+            every { sshUrl }.returns("ssh://repo.git")
+        }
+        every { getRepository.execute(any(), any()) }.returns(repository)
+
+        every { targetTranslation.repo }.returns(repo)
+        every { targetTranslation.path }.returns(mockk())
+
+        // a repository that was just created is empty and advertises no refs
+        every { pullCommand.call() }.throws(
+            RefNotAdvertisedException("Remote origin did not advertise Ref for branch master.")
+        )
+
+        val result = PullTargetTranslation(
+            context,
+            submitNewLanguageRequests,
+            getRepository,
+            profile,
+            transportCallback
+        ).execute(
+            targetTranslation,
+            MergeStrategy.RECURSIVE,
+            null,
+            progressListener
+        )
+
+        assertEquals(PullTargetTranslation.Status.NO_REMOTE_BRANCH, result.status)
+        assertNull(result.message)
+
+        verify { progressListener.onProgress(any(), any(), "Downloading updates") }
         verify { pullCommand.call() }
     }
 }


### PR DESCRIPTION
A repository that was just created advertises no refs, so treat the resulting RefNotAdvertisedException as an expected NO_REMOTE_BRANCH status instead of logging it as an error under UNKNOWN.

Fixes #341.

Changes in this pull request:
- Don't report missing branch name for new repos as error